### PR TITLE
Modified the (Kafka) Producer to simplify unit testing.

### DIFF
--- a/prototype2/common/Producer.cpp
+++ b/prototype2/common/Producer.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <libs/include/gccintel.h>
 
-Producer::Producer(std::string broker, std::string topicstr) {
+Producer::Producer(std::string broker, std::string topicstr) : ProducerBase() {
 
   conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
   tconf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);

--- a/prototype2/common/Producer.h
+++ b/prototype2/common/Producer.h
@@ -9,7 +9,12 @@
 
 #include <librdkafka/rdkafkacpp.h>
 
-class Producer {
+class ProducerBase {
+public:
+  virtual int produce(char *buffer, int length) = 0;
+};
+
+class Producer : public ProducerBase {
 public:
   /** @brief Construct a producer object.
    * @param broker 'URL' specifying host and port, example "127.0.0.1:9009"
@@ -24,7 +29,7 @@ public:
    *  @param buffer Pointer to char buffer containing data to be tx'ed
    *  @param length Size of buffer data in bytes
    */
-  int produce(char *buffer, int length);
+  int produce(char *buffer, int length) override;
 
 private:
   std::string errstr;


### PR DESCRIPTION
This relatively simple change is required for doing proper unit tests in the design of the fast sample environment processing that I have selected. See the relevant JIRA ticket (DM-812).