### PR TITLE
Memory leak fixes.

### DIFF
--- a/prototype2/common/Detector.h
+++ b/prototype2/common/Detector.h
@@ -53,6 +53,8 @@ public:
   /** @brief generic pthread argument
    * @param arg user supplied pointer to pthread argument data
    */
+  
+  virtual ~Detector() = default;
 
   /** @brief document */
   virtual int statsize() { return Stats.size(); }

--- a/prototype2/common/Producer.h
+++ b/prototype2/common/Producer.h
@@ -11,6 +11,8 @@
 
 class ProducerBase {
 public:
+  ProducerBase() = default;
+  virtual ~ProducerBase() = default;
   virtual int produce(char *buffer, int length) = 0;
 };
 


### PR DESCRIPTION
By making the destructor virtual, we remove potential memory leaks.