### PR TITLE
DM-807 Archive Jenkins artefact

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,8 +273,7 @@ def get_release_pipeline()
                 \""""
 
                 sh """docker exec ${container_name} ${custom_sh} -c \"
-                    cd \${project}
-                    cd ${project} && \
+                    cd ${project}
                     BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
                     cd ../build && \
                     . ./activate_run.sh && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -346,11 +346,11 @@ node('docker') {
 
     def builders = [:]
 
-    // for (x in images.keySet()) {
-    //     def image_key = x
-    //     builders[image_key] = get_pipeline(image_key)
-    // }
-    // builders['macOS'] = get_macos_pipeline()
+    for (x in images.keySet()) {
+        def image_key = x
+        builders[image_key] = get_pipeline(image_key)
+    }
+    builders['macOS'] = get_macos_pipeline()
     builders['release-centos7'] = get_release_pipeline()
 
     parallel builders

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -245,9 +245,9 @@ def get_release_pipeline()
     return {
         stage("release-centos7") {
             node('docker') {
+                def container_name = "${base_container_name}-release-centos7"
                 try {
                     def image = docker.image("essdmscdm/centos7-build-node:1.0.1")
-                    def container_name = "${base_container_name}-release-centos7"
                     def container = image.run("\
                         --name ${container_name} \
                         --tty \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,7 +273,7 @@ def get_release_pipeline()
                 \""""
 
                 sh """docker exec ${container_name} ${custom_sh} -c \"
-                    cd ${project}
+                    cd efu
                     BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
                     cd ../build && \
                     . ./activate_run.sh && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,8 +243,8 @@ def get_release_pipeline()
 {
     // Build with release settings to archive artefacts.
     return {
-        node('docker') {
-            stage("release-centos7") {
+        stage("release-centos7") {
+            node('docker') {
                 try {
                     def image = docker.image("essdmscdm/centos7-build-node:1.0.1")
                     def container_name = "${base_container_name}-release-centos7"
@@ -264,48 +264,48 @@ def get_release_pipeline()
                             ${project}
                     \""""
 
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        mkdir build && \
-                        cd build && \
-                        conan remote add \
-                            --insert 0 \
-                            ${conan_remote} ${local_conan_server} && \
-                        conan install --build=outdated ../${project}
-                    \""""
-
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        cd ${project} && \
-                        BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
-                        cd ../build && \
-                        . ./activate_run.sh && \
-                        cmake --version && \
-                        cmake \
-                            -DCMAKE_BUILD_TYPE=Release \
-                            -DCMAKE_SKIP_BUILD_RPATH=ON \
-                            -DBUILDSTR=\$BUILDSTR \
-                            -DDUMPTOFILE=ON \
-                            ../${project}
-                    \""""
-
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        cd build && \
-                        . ./activate_run.sh && \
-                        make VERBOSE=ON -j4 && \
-                        make VERBOSE=ON -j4 runefu && \
-                        make VERBOSE=ON -j4 runtest
-                    \""""
-
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        mkdir -p archive/efu-centos7 && \
-                        cp -r build/bin /archive/efu-centos7 && \
-                        cp -r build/lib /archive/efu-centos7 && \
-                        cp -r build/licenses /archive/efu-centos7 && \
-                        cd archive && \
-                        tar czvf efu-centos7.tar.gz efu-centos7
-                    \""""
-
-                    sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
-                    archiveArtifacts "efu-centos7.tar.gz"
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     mkdir build && \
+                    //     cd build && \
+                    //     conan remote add \
+                    //         --insert 0 \
+                    //         ${conan_remote} ${local_conan_server} && \
+                    //     conan install --build=outdated ../${project}
+                    // \""""
+                    //
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     cd ${project} && \
+                    //     BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
+                    //     cd ../build && \
+                    //     . ./activate_run.sh && \
+                    //     cmake --version && \
+                    //     cmake \
+                    //         -DCMAKE_BUILD_TYPE=Release \
+                    //         -DCMAKE_SKIP_BUILD_RPATH=ON \
+                    //         -DBUILDSTR=\$BUILDSTR \
+                    //         -DDUMPTOFILE=ON \
+                    //         ../${project}
+                    // \""""
+                    //
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     cd build && \
+                    //     . ./activate_run.sh && \
+                    //     make VERBOSE=ON -j4 && \
+                    //     make VERBOSE=ON -j4 runefu && \
+                    //     make VERBOSE=ON -j4 runtest
+                    // \""""
+                    //
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     mkdir -p archive/efu-centos7 && \
+                    //     cp -r build/bin /archive/efu-centos7 && \
+                    //     cp -r build/lib /archive/efu-centos7 && \
+                    //     cp -r build/licenses /archive/efu-centos7 && \
+                    //     cd archive && \
+                    //     tar czvf efu-centos7.tar.gz efu-centos7
+                    // \""""
+                    //
+                    // sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
+                    // archiveArtifacts "efu-centos7.tar.gz"
                 } catch(e) {
                     failure_function(e, "Unknown build failure for release-centos7")
                 } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -257,55 +257,55 @@ def get_release_pipeline()
                         ")
                     def custom_sh = "sh"
 
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        git clone \
-                            --branch ${env.BRANCH_NAME} \
-                            https://github.com/ess-dmsc/event-formation-unit.git \
-                            ${project}
-                    \""""
-
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        mkdir build && \
-                        cd build && \
-                        conan remote add \
-                            --insert 0 \
-                            ${conan_remote} ${local_conan_server} && \
-                        conan install --build=outdated ../${project}
-                    \""""
-
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        cd ${project} && \
-                        BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
-                        cd ../build && \
-                        . ./activate_run.sh && \
-                        cmake --version && \
-                        cmake \
-                            -DCMAKE_BUILD_TYPE=Release \
-                            -DCMAKE_SKIP_BUILD_RPATH=ON \
-                            -DBUILDSTR=\$BUILDSTR \
-                            -DDUMPTOFILE=ON \
-                            ../${project}
-                    \""""
-
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        cd build && \
-                        . ./activate_run.sh && \
-                        make VERBOSE=ON -j4 && \
-                        make VERBOSE=ON -j4 runefu && \
-                        make VERBOSE=ON -j4 runtest
-                    \""""
-
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        mkdir -p archive/efu-centos7 && \
-                        cp -r build/bin /archive/efu-centos7 && \
-                        cp -r build/lib /archive/efu-centos7 && \
-                        cp -r build/licenses /archive/efu-centos7 && \
-                        cd archive && \
-                        tar czvf efu-centos7.tar.gz efu-centos7
-                    \""""
-
-                    sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
-                    archiveArtifacts "efu-centos7.tar.gz"
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     git clone \
+                    //         --branch ${env.BRANCH_NAME} \
+                    //         https://github.com/ess-dmsc/event-formation-unit.git \
+                    //         ${project}
+                    // \""""
+                    //
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     mkdir build && \
+                    //     cd build && \
+                    //     conan remote add \
+                    //         --insert 0 \
+                    //         ${conan_remote} ${local_conan_server} && \
+                    //     conan install --build=outdated ../${project}
+                    // \""""
+                    // 
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     cd ${project} && \
+                    //     BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
+                    //     cd ../build && \
+                    //     . ./activate_run.sh && \
+                    //     cmake --version && \
+                    //     cmake \
+                    //         -DCMAKE_BUILD_TYPE=Release \
+                    //         -DCMAKE_SKIP_BUILD_RPATH=ON \
+                    //         -DBUILDSTR=\$BUILDSTR \
+                    //         -DDUMPTOFILE=ON \
+                    //         ../${project}
+                    // \""""
+                    //
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     cd build && \
+                    //     . ./activate_run.sh && \
+                    //     make VERBOSE=ON -j4 && \
+                    //     make VERBOSE=ON -j4 runefu && \
+                    //     make VERBOSE=ON -j4 runtest
+                    // \""""
+                    //
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     mkdir -p archive/efu-centos7 && \
+                    //     cp -r build/bin /archive/efu-centos7 && \
+                    //     cp -r build/lib /archive/efu-centos7 && \
+                    //     cp -r build/licenses /archive/efu-centos7 && \
+                    //     cd archive && \
+                    //     tar czvf efu-centos7.tar.gz efu-centos7
+                    // \""""
+                    //
+                    // sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
+                    // archiveArtifacts "efu-centos7.tar.gz"
                 } catch(e) {
                     failure_function(e, "Unknown build failure for release-centos7")
                 } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,73 +243,75 @@ def get_release_pipeline()
 {
     // Build with release settings to archive artefacts.
     return {
-        stage("release-centos7") {
-            try {
-                def image = docker.image("essdmscdm/centos7-build-node:1.0.1")
-                def container_name = "${base_container_name}-release-centos7"
-                def container = image.run("\
-                    --name ${container_name} \
-                    --tty \
-                    --env http_proxy=${env.http_proxy} \
-                    --env https_proxy=${env.https_proxy} \
-                    --env local_conan_server=${env.local_conan_server} \
-                    ")
-                def custom_sh = "sh"
+        node('docker') {
+            stage("release-centos7") {
+                try {
+                    def image = docker.image("essdmscdm/centos7-build-node:1.0.1")
+                    def container_name = "${base_container_name}-release-centos7"
+                    def container = image.run("\
+                        --name ${container_name} \
+                        --tty \
+                        --env http_proxy=${env.http_proxy} \
+                        --env https_proxy=${env.https_proxy} \
+                        --env local_conan_server=${env.local_conan_server} \
+                        ")
+                    def custom_sh = "sh"
 
-                sh """docker exec ${container_name} ${custom_sh} -c \"
-                    git clone \
-                        --branch ${env.BRANCH_NAME} \
-                        https://github.com/ess-dmsc/event-formation-unit.git \
-                        ${project}
-                \""""
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        git clone \
+                            --branch ${env.BRANCH_NAME} \
+                            https://github.com/ess-dmsc/event-formation-unit.git \
+                            ${project}
+                    \""""
 
-                sh """docker exec ${container_name} ${custom_sh} -c \"
-                    mkdir build && \
-                    cd build && \
-                    conan remote add \
-                        --insert 0 \
-                        ${conan_remote} ${local_conan_server} && \
-                    conan install --build=outdated ../${project}
-                \""""
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        mkdir build && \
+                        cd build && \
+                        conan remote add \
+                            --insert 0 \
+                            ${conan_remote} ${local_conan_server} && \
+                        conan install --build=outdated ../${project}
+                    \""""
 
-                sh """docker exec ${container_name} ${custom_sh} -c \"
-                    cd efu
-                    BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
-                    cd ../build && \
-                    . ./activate_run.sh && \
-                    cmake --version && \
-                    cmake \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DCMAKE_SKIP_BUILD_RPATH=ON \
-                        -DBUILDSTR=\$BUILDSTR \
-                        -DDUMPTOFILE=ON \
-                        ../${project}
-                \""""
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        cd ${project} && \
+                        BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
+                        cd ../build && \
+                        . ./activate_run.sh && \
+                        cmake --version && \
+                        cmake \
+                            -DCMAKE_BUILD_TYPE=Release \
+                            -DCMAKE_SKIP_BUILD_RPATH=ON \
+                            -DBUILDSTR=\$BUILDSTR \
+                            -DDUMPTOFILE=ON \
+                            ../${project}
+                    \""""
 
-                sh """docker exec ${container_name} ${custom_sh} -c \"
-                    cd build && \
-                    . ./activate_run.sh && \
-                    make VERBOSE=ON -j4 && \
-                    make VERBOSE=ON -j4 runefu && \
-                    make VERBOSE=ON -j4 runtest
-                \""""
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        cd build && \
+                        . ./activate_run.sh && \
+                        make VERBOSE=ON -j4 && \
+                        make VERBOSE=ON -j4 runefu && \
+                        make VERBOSE=ON -j4 runtest
+                    \""""
 
-                sh """docker exec ${container_name} ${custom_sh} -c \"
-                    mkdir -p archive/efu-centos7 && \
-                    cp -r build/bin /archive/efu-centos7 && \
-                    cp -r build/lib /archive/efu-centos7 && \
-                    cp -r build/licenses /archive/efu-centos7 && \
-                    cd archive && \
-                    tar czvf efu-centos7.tar.gz efu-centos7
-                \""""
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        mkdir -p archive/efu-centos7 && \
+                        cp -r build/bin /archive/efu-centos7 && \
+                        cp -r build/lib /archive/efu-centos7 && \
+                        cp -r build/licenses /archive/efu-centos7 && \
+                        cd archive && \
+                        tar czvf efu-centos7.tar.gz efu-centos7
+                    \""""
 
-                sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
-                archiveArtifacts "efu-centos7.tar.gz"
-            } catch(e) {
-                failure_function(e, "Unknown build failure for release-centos7")
-            } finally {
-                sh "docker stop ${container_name}"
-                sh "docker rm -f ${container_name}"
+                    sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
+                    archiveArtifacts "efu-centos7.tar.gz"
+                } catch(e) {
+                    failure_function(e, "Unknown build failure for release-centos7")
+                } finally {
+                    sh "docker stop ${container_name}"
+                    sh "docker rm -f ${container_name}"
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,7 +261,7 @@ def get_release_pipeline()
                         git clone \
                             --branch ${env.BRANCH_NAME} \
                             https://github.com/ess-dmsc/event-formation-unit.git \
-                            efu
+                            ${project}
                     \""""
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"
@@ -270,11 +270,11 @@ def get_release_pipeline()
                         conan remote add \
                             --insert 0 \
                             ${conan_remote} ${local_conan_server} && \
-                        conan install --build=outdated ../efu
+                        conan install --build=outdated ../${project}
                     \""""
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"
-                        cd efu && \
+                        cd ${project} && \
                         BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
                         cd ../build && \
                         . ./activate_run.sh && \
@@ -284,7 +284,7 @@ def get_release_pipeline()
                             -DCMAKE_SKIP_BUILD_RPATH=ON \
                             -DBUILDSTR=\$BUILDSTR \
                             -DDUMPTOFILE=ON \
-                            ../efu
+                            ../${project}
                     \""""
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,8 +292,7 @@ def get_release_pipeline()
                         cd build && \
                         . ./activate_run.sh && \
                         make VERBOSE=ON -j4 && \
-                        make VERBOSE=ON -j4 runefu && \
-                        make VERBOSE=ON -j4 runtest
+                        make VERBOSE=ON -j4 runefu
                     \""""
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,6 +148,11 @@ def get_pipeline(image_key)
                     def container = get_container(image_key)
                     def custom_sh = images[image_key]['sh']
 
+                    // Break build to test notification
+                    if (image_key == "centos7" || image_key == "fedora25") {
+                        1 / 0
+                    }
+
                     docker_clone(image_key)
                     docker_dependencies(image_key)
                     docker_cmake(image_key)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,11 +148,6 @@ def get_pipeline(image_key)
                     def container = get_container(image_key)
                     def custom_sh = images[image_key]['sh']
 
-                    // Break build to test notification
-                    if (image_key == "centos7" || image_key == "fedora25") {
-                        1 / 0
-                    }
-
                     docker_clone(image_key)
                     docker_dependencies(image_key)
                     docker_cmake(image_key)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -257,12 +257,12 @@ def get_release_pipeline()
                         ")
                     def custom_sh = "sh"
 
-                    sh """docker exec ${container_name} ${custom_sh} -c \"
-                        git clone \
-                            --branch ${env.BRANCH_NAME} \
-                            https://github.com/ess-dmsc/event-formation-unit.git \
-                            ${project}
-                    \""""
+                    // sh """docker exec ${container_name} ${custom_sh} -c \"
+                    //     git clone \
+                    //         --branch ${env.BRANCH_NAME} \
+                    //         https://github.com/ess-dmsc/event-formation-unit.git \
+                    //         ${project}
+                    // \""""
 
                     // sh """docker exec ${container_name} ${custom_sh} -c \"
                     //     mkdir build && \
@@ -345,11 +345,11 @@ node('docker') {
 
     def builders = [:]
 
-    for (x in images.keySet()) {
-        def image_key = x
-        builders[image_key] = get_pipeline(image_key)
-    }
-    builders['macOS'] = get_macos_pipeline()
+    // for (x in images.keySet()) {
+    //     def image_key = x
+    //     builders[image_key] = get_pipeline(image_key)
+    // }
+    // builders['macOS'] = get_macos_pipeline()
     builders['release-centos7'] = get_release_pipeline()
 
     parallel builders

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ def Object container_name(image_key) {
 }
 
 def docker_clone(image_key) {
-    sh """docker exec ${container_name} ${custom_sh} -c \"
+    sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         git clone \
             --branch ${env.BRANCH_NAME} \
             https://github.com/ess-dmsc/event-formation-unit.git

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -239,7 +239,7 @@ def get_macos_pipeline()
     }
 }
 
-node('docker && dmbuild03.dm.esss.dk') {
+node('docker') {
 
     // Delete workspace when build is done
     cleanWs()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -245,9 +245,10 @@ def get_release_pipeline()
     return {
         stage("release-centos7") {
             try {
-                def image = docker.image(images[image_key]['name'])
+                def image = docker.image("essdmscdm/centos7-build-node:1.0.1")
+                def container_name = "${base_container_name}-release-centos7"
                 def container = image.run("\
-                    --name ${base_container_name}-release-centos7 \
+                    --name ${container_name} \
                     --tty \
                     --env http_proxy=${env.http_proxy} \
                     --env https_proxy=${env.https_proxy} \
@@ -307,8 +308,8 @@ def get_release_pipeline()
             } catch(e) {
                 failure_function(e, "Unknown build failure for release-centos7")
             } finally {
-                sh "docker stop ${base_container_name}-release-centos7"
-                sh "docker rm -f ${base_container_name}-release-centos7"
+                sh "docker stop ${container_name}"
+                sh "docker rm -f ${container_name}"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -297,9 +297,9 @@ def get_release_pipeline()
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"
                         mkdir -p archive/efu-centos7 && \
-                        cp -r build/bin /archive/efu-centos7 && \
-                        cp -r build/lib /archive/efu-centos7 && \
-                        cp -r build/licenses /archive/efu-centos7 && \
+                        cp -r build/bin archive/efu-centos7 && \
+                        cp -r build/lib archive/efu-centos7 && \
+                        cp -r build/licenses archive/efu-centos7 && \
                         cd archive && \
                         tar czvf efu-centos7.tar.gz efu-centos7
                     \""""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,7 +261,7 @@ def get_release_pipeline()
                         git clone \
                             --branch ${env.BRANCH_NAME} \
                             https://github.com/ess-dmsc/event-formation-unit.git \
-                            ${project}
+                            efu
                     \""""
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"
@@ -270,11 +270,11 @@ def get_release_pipeline()
                         conan remote add \
                             --insert 0 \
                             ${conan_remote} ${local_conan_server} && \
-                        conan install --build=outdated ../${project}
+                        conan install --build=outdated ../efu
                     \""""
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"
-                        cd ${project} && \
+                        cd efu && \
                         BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
                         cd ../build && \
                         . ./activate_run.sh && \
@@ -284,7 +284,7 @@ def get_release_pipeline()
                             -DCMAKE_SKIP_BUILD_RPATH=ON \
                             -DBUILDSTR=\$BUILDSTR \
                             -DDUMPTOFILE=ON \
-                            ../${project}
+                            ../efu
                     \""""
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -276,14 +276,14 @@ def get_release_pipeline()
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"
                         cd ${project} && \
-                        BUILDSTR=\$(git log --oneline | head -n 1 | awk '{print \$1}') && \
+                        BUILDSTR=\\\$(git log --oneline | head -n 1 | awk '{print \\\$1}') && \
                         cd ../build && \
                         . ./activate_run.sh && \
                         cmake --version && \
                         cmake \
                             -DCMAKE_BUILD_TYPE=Release \
                             -DCMAKE_SKIP_BUILD_RPATH=ON \
-                            -DBUILDSTR=\$BUILDSTR \
+                            -DBUILDSTR=\\\$BUILDSTR \
                             -DDUMPTOFILE=ON \
                             ../${project}
                     \""""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,56 +256,57 @@ def get_release_pipeline()
                         --env local_conan_server=${env.local_conan_server} \
                         ")
                     def custom_sh = "sh"
+                    def conan_remote = "ess-dmsc-local"
 
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     git clone \
-                    //         --branch ${env.BRANCH_NAME} \
-                    //         https://github.com/ess-dmsc/event-formation-unit.git \
-                    //         ${project}
-                    // \""""
-                    //
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     mkdir build && \
-                    //     cd build && \
-                    //     conan remote add \
-                    //         --insert 0 \
-                    //         ${conan_remote} ${local_conan_server} && \
-                    //     conan install --build=outdated ../${project}
-                    // \""""
-                    // 
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     cd ${project} && \
-                    //     BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
-                    //     cd ../build && \
-                    //     . ./activate_run.sh && \
-                    //     cmake --version && \
-                    //     cmake \
-                    //         -DCMAKE_BUILD_TYPE=Release \
-                    //         -DCMAKE_SKIP_BUILD_RPATH=ON \
-                    //         -DBUILDSTR=\$BUILDSTR \
-                    //         -DDUMPTOFILE=ON \
-                    //         ../${project}
-                    // \""""
-                    //
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     cd build && \
-                    //     . ./activate_run.sh && \
-                    //     make VERBOSE=ON -j4 && \
-                    //     make VERBOSE=ON -j4 runefu && \
-                    //     make VERBOSE=ON -j4 runtest
-                    // \""""
-                    //
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     mkdir -p archive/efu-centos7 && \
-                    //     cp -r build/bin /archive/efu-centos7 && \
-                    //     cp -r build/lib /archive/efu-centos7 && \
-                    //     cp -r build/licenses /archive/efu-centos7 && \
-                    //     cd archive && \
-                    //     tar czvf efu-centos7.tar.gz efu-centos7
-                    // \""""
-                    //
-                    // sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
-                    // archiveArtifacts "efu-centos7.tar.gz"
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        git clone \
+                            --branch ${env.BRANCH_NAME} \
+                            https://github.com/ess-dmsc/event-formation-unit.git \
+                            ${project}
+                    \""""
+
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        mkdir build && \
+                        cd build && \
+                        conan remote add \
+                            --insert 0 \
+                            ${conan_remote} ${local_conan_server} && \
+                        conan install --build=outdated ../${project}
+                    \""""
+
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        cd ${project} && \
+                        BUILDSTR=\$(git log --oneline | head -n 1 | awk '{print \$1}') && \
+                        cd ../build && \
+                        . ./activate_run.sh && \
+                        cmake --version && \
+                        cmake \
+                            -DCMAKE_BUILD_TYPE=Release \
+                            -DCMAKE_SKIP_BUILD_RPATH=ON \
+                            -DBUILDSTR=\$BUILDSTR \
+                            -DDUMPTOFILE=ON \
+                            ../${project}
+                    \""""
+
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        cd build && \
+                        . ./activate_run.sh && \
+                        make VERBOSE=ON -j4 && \
+                        make VERBOSE=ON -j4 runefu && \
+                        make VERBOSE=ON -j4 runtest
+                    \""""
+
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        mkdir -p archive/efu-centos7 && \
+                        cp -r build/bin /archive/efu-centos7 && \
+                        cp -r build/lib /archive/efu-centos7 && \
+                        cp -r build/licenses /archive/efu-centos7 && \
+                        cd archive && \
+                        tar czvf efu-centos7.tar.gz efu-centos7
+                    \""""
+
+                    sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
+                    archiveArtifacts "efu-centos7.tar.gz"
                 } catch(e) {
                     failure_function(e, "Unknown build failure for release-centos7")
                 } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -257,55 +257,55 @@ def get_release_pipeline()
                         ")
                     def custom_sh = "sh"
 
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     git clone \
-                    //         --branch ${env.BRANCH_NAME} \
-                    //         https://github.com/ess-dmsc/event-formation-unit.git \
-                    //         ${project}
-                    // \""""
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        git clone \
+                            --branch ${env.BRANCH_NAME} \
+                            https://github.com/ess-dmsc/event-formation-unit.git \
+                            ${project}
+                    \""""
 
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     mkdir build && \
-                    //     cd build && \
-                    //     conan remote add \
-                    //         --insert 0 \
-                    //         ${conan_remote} ${local_conan_server} && \
-                    //     conan install --build=outdated ../${project}
-                    // \""""
-                    //
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     cd ${project} && \
-                    //     BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
-                    //     cd ../build && \
-                    //     . ./activate_run.sh && \
-                    //     cmake --version && \
-                    //     cmake \
-                    //         -DCMAKE_BUILD_TYPE=Release \
-                    //         -DCMAKE_SKIP_BUILD_RPATH=ON \
-                    //         -DBUILDSTR=\$BUILDSTR \
-                    //         -DDUMPTOFILE=ON \
-                    //         ../${project}
-                    // \""""
-                    //
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     cd build && \
-                    //     . ./activate_run.sh && \
-                    //     make VERBOSE=ON -j4 && \
-                    //     make VERBOSE=ON -j4 runefu && \
-                    //     make VERBOSE=ON -j4 runtest
-                    // \""""
-                    //
-                    // sh """docker exec ${container_name} ${custom_sh} -c \"
-                    //     mkdir -p archive/efu-centos7 && \
-                    //     cp -r build/bin /archive/efu-centos7 && \
-                    //     cp -r build/lib /archive/efu-centos7 && \
-                    //     cp -r build/licenses /archive/efu-centos7 && \
-                    //     cd archive && \
-                    //     tar czvf efu-centos7.tar.gz efu-centos7
-                    // \""""
-                    //
-                    // sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
-                    // archiveArtifacts "efu-centos7.tar.gz"
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        mkdir build && \
+                        cd build && \
+                        conan remote add \
+                            --insert 0 \
+                            ${conan_remote} ${local_conan_server} && \
+                        conan install --build=outdated ../${project}
+                    \""""
+
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        cd ${project} && \
+                        BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
+                        cd ../build && \
+                        . ./activate_run.sh && \
+                        cmake --version && \
+                        cmake \
+                            -DCMAKE_BUILD_TYPE=Release \
+                            -DCMAKE_SKIP_BUILD_RPATH=ON \
+                            -DBUILDSTR=\$BUILDSTR \
+                            -DDUMPTOFILE=ON \
+                            ../${project}
+                    \""""
+
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        cd build && \
+                        . ./activate_run.sh && \
+                        make VERBOSE=ON -j4 && \
+                        make VERBOSE=ON -j4 runefu && \
+                        make VERBOSE=ON -j4 runtest
+                    \""""
+
+                    sh """docker exec ${container_name} ${custom_sh} -c \"
+                        mkdir -p archive/efu-centos7 && \
+                        cp -r build/bin /archive/efu-centos7 && \
+                        cp -r build/lib /archive/efu-centos7 && \
+                        cp -r build/licenses /archive/efu-centos7 && \
+                        cd archive && \
+                        tar czvf efu-centos7.tar.gz efu-centos7
+                    \""""
+
+                    sh "docker cp ${container_name}:/home/jenkins/archive/efu-centos7.tar.gz ."
+                    archiveArtifacts "efu-centos7.tar.gz"
                 } catch(e) {
                     failure_function(e, "Unknown build failure for release-centos7")
                 } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,6 +273,7 @@ def get_release_pipeline()
                 \""""
 
                 sh """docker exec ${container_name} ${custom_sh} -c \"
+                    cd \${project}
                     cd ${project} && \
                     BUILDSTR=$(git log --oneline | head -n 1 | awk '{print \$1}') && \
                     cd ../build && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ def docker_clone(image_key) {
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         git clone \
             --branch ${env.BRANCH_NAME} \
-            https://github.com/ess-dmsc/event-formation-unit.git
+            https://github.com/ess-dmsc/event-formation-unit.git ${project}
     \""""
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ def Object container_name(image_key) {
 }
 
 def docker_clone(image_key) {
+    def custom_sh = images[image_key]['sh']
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         git clone \
             --branch ${env.BRANCH_NAME} \

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -17,3 +17,7 @@ virtualrunenv
 [options]
 gtest:shared=True
 librdkafka:shared=True
+
+[imports]
+lib, * -> ./lib
+., LICENSE* -> ./licenses @ folder=True, ignore_case=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -7,7 +7,7 @@ h5cpp/0.0.4-dm1@ess-dmsc/stable
 logical-geometry/09097f2@ess-dmsc/stable
 cmake_installer/3.10.0@conan/stable
 asio/1.11.0@bincrafters/stable
-cli11/1.4-dm1@ess-dmsc/stable
+cli11/1.4-dm2@ess-dmsc/stable
 
 [generators]
 cmake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -20,4 +20,5 @@ librdkafka:shared=True
 
 [imports]
 lib, * -> ./lib
+lib64, * -> ./lib
 ., LICENSE* -> ./licenses @ folder=True, ignore_case=True

--- a/prototype2/efu/CMakeLists.txt
+++ b/prototype2/efu/CMakeLists.txt
@@ -23,6 +23,11 @@ set(efu_INC
   
 add_definitions(-std=c++11)
 create_executable(efu)
+get_filename_component(EFU_RUN_INSTRUCTIONS "Executing artefacts.md" ABSOLUTE)
+add_custom_command(TARGET efu POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy
+                ${EFU_RUN_INSTRUCTIONS}
+                "$<TARGET_FILE_DIR:efu>/")
 
 #=============================================================================
 # EFU Tests

--- a/prototype2/efu/Executing artefacts.md
+++ b/prototype2/efu/Executing artefacts.md
@@ -1,0 +1,7 @@
+# Running artefacts
+
+If you have downloaded the binary aretfacts of this repository compiled using our Jenkins build nodes, you will need to manually set the path to the *lib* directory. This is done by setting the `LD_LIBRARY_PATH` environment variable. E.g. to run the EFU using the sonde module, execute the following line:
+
+```
+LD_LIBRARY_PATH=../lib ./efu -d ../lib/sonde
+```


### PR DESCRIPTION
Modify Jenkinsfile to build EFU in release mode and archive artefact for CentOS 7. The changes also distribute the containers among all of the build nodes and limits the use of the email notification function. This last change was made to prevent Jenkins from sending more than one email per broken build (e.g. if multiple containers fail) – by doing this we lose the details of which build and where the job failed, though.