### PR TITLE
Optimized the ADC code a bit and increased buffer sizes

### DIFF
--- a/prototype2/adc_readout/AdcBufferElements.h
+++ b/prototype2/adc_readout/AdcBufferElements.h
@@ -11,7 +11,7 @@
 
 /// @brief Buffer used to store raw data from the UDP socket.
 struct InData {
-  static const int MaxLength = 2048;
+  static const int MaxLength = 10000;
   std::uint8_t Data[MaxLength] = {};
   unsigned int Length = 0;
 };

--- a/prototype2/adc_readout/AdcParse.cpp
+++ b/prototype2/adc_readout/AdcParse.cpp
@@ -113,8 +113,9 @@ AdcData parseData(const InData &Packet, std::uint32_t StartByte) {
         Packet.Length) {
       throw ParserException(ParserException::Type::DATA_LENGTH);
     }
-    DataModule CurrentDataModule;
-    CurrentDataModule.Data.resize(NrOfSamples);
+    ReturnData.Modules.emplace_back(NrOfSamples);
+    
+    DataModule &CurrentDataModule = ReturnData.Modules[ReturnData.Modules.size() - 1];
     CurrentDataModule.Channel = Header.Channel;
     CurrentDataModule.TimeStamp = Header.TimeStamp;
     auto ElementPointer = reinterpret_cast<const std::uint16_t *>(
@@ -129,7 +130,6 @@ AdcData parseData(const InData &Packet, std::uint32_t StartByte) {
       throw ParserException(ParserException::Type::DATA_BEEFCAFE);
     }
     StartByte += 4;
-    ReturnData.Modules.emplace_back(CurrentDataModule);
   }
   ReturnData.FillerStart = StartByte;
   return ReturnData;

--- a/prototype2/adc_readout/AdcParse.h
+++ b/prototype2/adc_readout/AdcParse.h
@@ -57,7 +57,7 @@ struct DataModule {
   DataModule(size_t NrOfElements) noexcept : Data(NrOfElements) {}
   ~DataModule() = default;
   DataModule(const DataModule &&Other) : TimeStamp(Other.TimeStamp), Channel(Other.Channel), OversamplingFactor(Other.OversamplingFactor), Data(std::move(Other.Data)) {}
-  DataModule& operator=( const DataModule& Other ) = default;
+  DataModule& operator=( const DataModule&) = default;
   RawTimeStamp TimeStamp;
   std::uint16_t Channel;
   std::uint16_t OversamplingFactor{1};

--- a/prototype2/adc_readout/AdcParse.h
+++ b/prototype2/adc_readout/AdcParse.h
@@ -54,6 +54,10 @@ private:
 /// @brief Data stored in this struct represents a (properly parsed) sampling run.
 struct DataModule {
   DataModule() = default;
+  DataModule(size_t NrOfElements) noexcept : Data(NrOfElements) {}
+  ~DataModule() = default;
+  DataModule(const DataModule &&Other) : TimeStamp(Other.TimeStamp), Channel(Other.Channel), OversamplingFactor(Other.OversamplingFactor), Data(std::move(Other.Data)) {}
+  DataModule& operator=( const DataModule& Other ) = default;
   RawTimeStamp TimeStamp;
   std::uint16_t Channel;
   std::uint16_t OversamplingFactor{1};

--- a/prototype2/adc_readout/SampleProcessing.cpp
+++ b/prototype2/adc_readout/SampleProcessing.cpp
@@ -25,7 +25,7 @@ std::uint64_t CalcSampleTimeStamp(const RawTimeStamp &Start,
 }
 
 double CalcTimeStampDelta(int OversamplingFactor) {
-  constexpr double SampleTime = 1.0 / AdcTimerCounterMax;
+  constexpr double SampleTime = 1e9 / AdcTimerCounterMax;
   return SampleTime * OversamplingFactor;
 }
 
@@ -38,9 +38,9 @@ ProcessedSamples ChannelProcessing::processModule(const DataModule &Samples) {
   ReturnSamples.TimeDelta = CalcTimeStampDelta(FinalOversamplingFactor);
   std::uint64_t TimeStampOffset{0};
   if (TSLocation == TimeStampLocation::Middle) {
-    TimeStampOffset = std::llround(0.5 * (1e9*ReturnSamples.TimeDelta  / FinalOversamplingFactor) * (FinalOversamplingFactor - 1));
+    TimeStampOffset = std::llround(0.5 * (ReturnSamples.TimeDelta  / FinalOversamplingFactor) * (FinalOversamplingFactor - 1));
   } else if (TSLocation == TimeStampLocation::End) {
-    TimeStampOffset = std::llround((1e9*ReturnSamples.TimeDelta  / FinalOversamplingFactor) * (FinalOversamplingFactor - 1));
+    TimeStampOffset = std::llround((ReturnSamples.TimeDelta  / FinalOversamplingFactor) * (FinalOversamplingFactor - 1));
   }
   
   for (size_t i = 0; i < Samples.Data.size(); i++) {

--- a/prototype2/adc_readout/SampleProcessing.cpp
+++ b/prototype2/adc_readout/SampleProcessing.cpp
@@ -8,6 +8,7 @@
 #include "SampleProcessing.h"
 #include "senv_data_generated.h"
 #include "AdcReadoutConstants.h"
+#include <cmath>
 
 std::uint64_t CalcSampleTimeStamp(const RawTimeStamp &Start,
                                   const RawTimeStamp &End,
@@ -29,31 +30,38 @@ double CalcTimeStampDelta(int OversamplingFactor) {
 }
 
 ProcessedSamples ChannelProcessing::processModule(const DataModule &Samples) {
-  ProcessedSamples ReturnSamples;
   int FinalOversamplingFactor = MeanOfNrOfSamples * Samples.OversamplingFactor;
-
+  size_t SampleIndex{0};
+  size_t TotalNumberOfSamples = (Samples.Data.size() + NrOfSamplesSummed) / MeanOfNrOfSamples;
+  ProcessedSamples ReturnSamples(TotalNumberOfSamples);
+  
+  ReturnSamples.TimeDelta = CalcTimeStampDelta(FinalOversamplingFactor);
+  std::uint64_t TimeStampOffset{0};
+  if (TSLocation == TimeStampLocation::Middle) {
+    TimeStampOffset = std::llround(0.5 * (1e9*ReturnSamples.TimeDelta  / FinalOversamplingFactor) * (FinalOversamplingFactor - 1));
+  } else if (TSLocation == TimeStampLocation::End) {
+    TimeStampOffset = std::llround((1e9*ReturnSamples.TimeDelta  / FinalOversamplingFactor) * (FinalOversamplingFactor - 1));
+  }
+  
   for (size_t i = 0; i < Samples.Data.size(); i++) {
     if (0 == NrOfSamplesSummed) {
       TimeStampOfFirstSample = Samples.TimeStamp.GetOffsetTimeStamp(
           i * Samples.OversamplingFactor - (Samples.OversamplingFactor - 1));
     }
-    SumOfSamples += Samples.Data.at(i);
+    SumOfSamples += Samples.Data[i];
     NrOfSamplesSummed++;
     if (NrOfSamplesSummed == MeanOfNrOfSamples) {
-      ReturnSamples.Samples.emplace_back(SumOfSamples /
-                                         FinalOversamplingFactor);
-      RawTimeStamp TimeStampOfLastSample =
-          Samples.TimeStamp.GetOffsetTimeStamp(i * Samples.OversamplingFactor);
-      ReturnSamples.TimeStamps.emplace_back(CalcSampleTimeStamp(
-          TimeStampOfFirstSample, TimeStampOfLastSample, TSLocation));
+      ReturnSamples.Samples[SampleIndex] = SumOfSamples / FinalOversamplingFactor;
+        ReturnSamples.TimeStamps[SampleIndex] = TimeStampOfFirstSample.GetTimeStampNS() + TimeStampOffset;
+
       ChannelProcessing::reset();
+      ++SampleIndex;
     }
   }
   if (not ReturnSamples.TimeStamps.empty()) {
-    ReturnSamples.TimeStamp = ReturnSamples.TimeStamps.at(0);
+    ReturnSamples.TimeStamp = ReturnSamples.TimeStamps[0];
   }
   ReturnSamples.Channel = Samples.Channel;
-  ReturnSamples.TimeDelta = CalcTimeStampDelta(FinalOversamplingFactor);
   return ReturnSamples;
 }
 
@@ -100,7 +108,7 @@ void SampleProcessing::processPacket(const PacketData &Data) {
       setMeanOfSamples(MeanOfNrOfSamples);
       setTimeStampLocation(TSLocation);
     }
-    auto ResultingSamples = ProcessingInstances.at(Module.Channel).processModule(Module);
+    auto ResultingSamples = ProcessingInstances[Module.Channel].processModule(Module);
     if (not ResultingSamples.Samples.empty()) {
       serializeAndTransmitData(ResultingSamples);
     }

--- a/prototype2/adc_readout/SampleProcessing.h
+++ b/prototype2/adc_readout/SampleProcessing.h
@@ -23,6 +23,8 @@ enum class TimeStampLocation {
 
 /// @brief Contains data that is to be serialized into a flatbuffer.
 struct ProcessedSamples {
+  ProcessedSamples() = default;
+  ProcessedSamples(size_t NrOfSamples) : Samples(NrOfSamples), TimeStamps(NrOfSamples) {}
   int Channel;
   std::uint64_t TimeStamp;
   double TimeDelta;

--- a/prototype2/adc_readout/test/SampleProcessingTest.cpp
+++ b/prototype2/adc_readout/test/SampleProcessingTest.cpp
@@ -332,6 +332,28 @@ TEST_F(ChannelProcessingTest, OversamplingAndTime8) {
   }
 }
 
+TEST_F(ChannelProcessingTest, OversamplingAndTime9) {
+  ChannelProcessing Processing;
+  Module.OversamplingFactor = 1;
+  Processing.setMeanOfSamples(1);
+  Processing.setTimeStampLocation(TimeStampLocation::Middle);
+  auto Result = Processing.processModule(Module);
+  for (unsigned int i = 0; i < Result.TimeStamps.size(); i++) {
+    EXPECT_EQ(Module.TimeStamp.GetOffsetTimeStamp(i).GetTimeStampNS(), Result.TimeStamps.at(i));
+  }
+}
+
+TEST_F(ChannelProcessingTest, OversamplingAndTime10) {
+  ChannelProcessing Processing;
+  Module.OversamplingFactor = 1;
+  Processing.setMeanOfSamples(1);
+  Processing.setTimeStampLocation(TimeStampLocation::End);
+  auto Result = Processing.processModule(Module);
+  for (unsigned int i = 0; i < Result.TimeStamps.size(); i++) {
+    EXPECT_EQ(Module.TimeStamp.GetOffsetTimeStamp(i).GetTimeStampNS(), Result.TimeStamps.at(i));
+  }
+}
+
 TEST_F(ChannelProcessingTest, DefaultSetup) {
   ChannelProcessing Processing;
   auto Result = Processing.processModule(Module);

--- a/prototype2/gdgem/nmxgen/wireshark.cpp
+++ b/prototype2/gdgem/nmxgen/wireshark.cpp
@@ -12,7 +12,7 @@
 
 int main(int argc, char *argv[]) {
   NMXArgs opts(argc, argv);
-  char buffer[9000];
+  char buffer[10000];
 
   Socket::Endpoint local("0.0.0.0", 0);
   Socket::Endpoint remote(opts.dest_ip.c_str(), opts.port);


### PR DESCRIPTION
Testing of the ADC pipeline of the EFU code revealed some problems. This pull request is a response to those. The changes are as follows:
 - Increased buffer sizes to allow for jumbo (super jumbo) frames now transmitted by the ADC hardware.
 - Fixed non-working `std::move`'s in order to minimise copying and improve performance.
 - Fixed bug in time stamp calculation.
 - Re-worked algorithm for calculating sample time stamps in order to drastically improve performance.
 - Added unit tests related to time stamp calculation.