### PR TITLE
Issue 24

### DIFF
--- a/prototype2/Utilities.cmake
+++ b/prototype2/Utilities.cmake
@@ -57,6 +57,10 @@ function(create_test_executable exec_name)
     ${EFU_COMMON_LIBS}
     ${GTEST_LIBRARIES})
 
+  if(${CMAKE_COMPILER_IS_GNUCXX})
+    add_linker_flags(${exec_name} "-Wl,--no-as-needed")
+  endif()
+
   add_test(NAME regular_${exec_name}
     COMMAND ${exec_name}
     "--gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${exec_name}test.xml")

--- a/prototype2/adc_readout/CMakeLists.txt
+++ b/prototype2/adc_readout/CMakeLists.txt
@@ -1,100 +1,80 @@
-cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
-
-project("AdcReadout" LANGUAGES CXX C)
-
-include_directories(${CMAKE_SOURCE_DIR})
+find_package(ASIO REQUIRED)
 
 set(AdcReadoutBase_SRC
-  AdcReadoutBase.cpp
-  AdcParse.cpp
-  PeakFinder.cpp
-  AdcDataProcessor.cpp
-  SampleProcessing.cpp
-  AdcSettings.cpp
-  AdcTimeStamp.cpp
-)
-
-set(AdcReadout_SRC
-  AdcReadout.cpp
-  ${AdcReadoutBase_SRC}
-)
+    AdcReadoutBase.cpp
+    AdcParse.cpp
+    PeakFinder.cpp
+    AdcDataProcessor.cpp
+    SampleProcessing.cpp
+    AdcSettings.cpp
+    AdcTimeStamp.cpp
+    )
 
 set(AdcReadoutBase_INC
-  AdcReadoutConstants.h
-  AdcReadoutBase.h
-  AdcParse.h
-  AdcBufferElements.h
-  atomicops.h
-  CircularBuffer.h
-  readerwriterqueue.h
-  PeakFinder.h
-  AdcDataProcessor.h
-  SampleProcessing.h
-  AdcSettings.h
-  AdcTimeStamp.h
-)
+    AdcReadoutConstants.h
+    AdcReadoutBase.h
+    AdcParse.h
+    AdcBufferElements.h
+    atomicops.h
+    CircularBuffer.h
+    readerwriterqueue.h
+    PeakFinder.h
+    AdcDataProcessor.h
+    SampleProcessing.h
+    AdcSettings.h
+    AdcTimeStamp.h
+    )
+
+
+set(AdcReadout_SRC
+    AdcReadout.cpp
+    ${AdcReadoutBase_SRC}
+    )
 
 set(AdcReadout_INC
-  ${AdcReadoutBase_INC}
-)
+    ${AdcReadoutBase_INC}
+    )
 
 create_module(AdcReadout "")
 
-enable_testing()
-
-include_directories(..)
 
 set(AdcReadoutTest_SRC
-  test/UnitTests.cpp
-  test/CircularBufferTest.cpp
-  test/AdcReadoutTest.cpp
-  test/AdcParseTest.cpp
-  test/TestUDPServer.cpp
-  test/PeakFinderTest.cpp
-  test/AdcDataProcessorTest.cpp
-  test/SampleProcessingTest.cpp
-  test/CLIArgumentsTest.cpp
-  test/AdcTimeStampTest.cpp
-  ${AdcReadoutBase_SRC})
+    test/UnitTests.cpp
+    test/CircularBufferTest.cpp
+    test/AdcReadoutTest.cpp
+    test/AdcParseTest.cpp
+    test/TestUDPServer.cpp
+    test/PeakFinderTest.cpp
+    test/AdcDataProcessorTest.cpp
+    test/SampleProcessingTest.cpp
+    test/CLIArgumentsTest.cpp
+    test/AdcTimeStampTest.cpp
+    ${AdcReadoutBase_SRC}
+    )
 
 set(AdcReadoutTest_INC
-  test/TestUDPServer.h
-  ${AdcReadoutBase_INC}
-)
+    test/TestUDPServer.h
+    ${AdcReadoutBase_INC}
+    )
 
-find_package(ASIO)
+set(AdcReadoutTest_LIB
+    eventlib
+    )
 
-if(${ASIO_FOUND})
-  
-  #create_test_executable(AdcReadoutTest ${LibRDKafka_LIBRARIES})
-  
-  add_executable(AdcReadoutTest EXCLUDE_FROM_ALL
-    ${AdcReadoutTest_SRC}
-    ${AdcReadoutTest_INC})
-  target_include_directories(AdcReadoutTest
-    PRIVATE ${GTEST_INCLUDE_DIRS})
+create_test_executable(AdcReadoutTest)
 
-  target_link_libraries(AdcReadoutTest
-    ${LibRDKafka_LIBRARIES}
-    ${EFU_COMMON_LIBS}
-    ${GTEST_LIBRARIES})
+#  add_test(NAME regular_AdcReadoutTest
+#    COMMAND AdcReadoutTest
+#    "--gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${exec_name}test.xml")
+#
+#  set(unit_test_targets
+#    ${unit_test_targets} AdcReadoutTest
+#    CACHE INTERNAL "All targets")
 
-  add_test(NAME regular_AdcReadoutTest
-    COMMAND AdcReadoutTest
-    "--gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${exec_name}test.xml")
+get_filename_component(TEST_PACKET_PATH "test/test_packet_1.dat" DIRECTORY)
+target_compile_definitions(AdcReadoutTest
+    PRIVATE TEST_PACKET_PATH="${CMAKE_CURRENT_SOURCE_DIR}/${TEST_PACKET_PATH}/")
+message(STATUS "Test ADC packets in path: ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_PACKET_PATH}/")
 
-  set(unit_test_targets
-    ${unit_test_targets} AdcReadoutTest
-    CACHE INTERNAL "All targets")
-
-  enable_coverage(AdcReadoutTest)
-  
-  get_filename_component(TEST_PACKET_PATH "test/test_packet_1.dat" DIRECTORY)
-  target_compile_definitions(AdcReadoutTest PRIVATE TEST_PACKET_PATH="${CMAKE_CURRENT_SOURCE_DIR}/${TEST_PACKET_PATH}/")
-  message(STATUS "Test ADC packets in path: ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_PACKET_PATH}/")
-
-  add_dependencies(AdcReadoutTest efu_common eventlib)
-  target_link_libraries(AdcReadoutTest efu_common eventlib)
-  target_include_directories(AdcReadoutTest PRIVATE ${ASIO_INCLUDE_DIR})
-  add_subdirectory("chopper_integration_test")
-endif()
+target_include_directories(AdcReadoutTest PRIVATE ${ASIO_INCLUDE_DIR})
+add_subdirectory("chopper_integration_test")

--- a/prototype2/adc_readout/test/TestUDPServer.cpp
+++ b/prototype2/adc_readout/test/TestUDPServer.cpp
@@ -12,13 +12,24 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wreorder"
-TestUDPServer::TestUDPServer(std::uint16_t SrcPort, std::uint16_t DstPort, int PacketSize) : Service(), Socket(Service, asio::ip::udp::endpoint(asio::ip::udp::v4(), SourcePort)), Resolver(Service), PacketTimer(Service), SourcePort(SrcPort), DestinationPort(DstPort) {
+TestUDPServer::TestUDPServer(std::uint16_t SrcPort, std::uint16_t DstPort, int PacketSize)
+    : Service()
+    , SourcePort(SrcPort)
+    , DestinationPort(DstPort)
+    , Socket(Service, asio::ip::udp::endpoint(asio::ip::udp::v4(), SourcePort))
+    , Resolver(Service)
+    , PacketTimer(Service) {
   BufferSize = PacketSize;
   SendBuffer = std::unique_ptr<std::uint8_t[]>(new std::uint8_t[PacketSize]);
 }
 
 TestUDPServer::TestUDPServer(std::uint16_t SrcPort, std::uint16_t DstPort, std::uint8_t *DataPtr, size_t DataLength)
-: Service(), Socket(Service, asio::ip::udp::endpoint(asio::ip::udp::v4(), SrcPort)), Resolver(Service), PacketTimer(Service), SourcePort(SrcPort), DestinationPort(DstPort) {
+    : Service()
+    , SourcePort(SrcPort)
+    , DestinationPort(DstPort)
+    , Socket(Service, asio::ip::udp::endpoint(asio::ip::udp::v4(), SrcPort))
+    , Resolver(Service)
+    , PacketTimer(Service) {
   BufferSize = DataLength;
   SendBuffer = std::unique_ptr<std::uint8_t[]>(new std::uint8_t[DataLength]);
   std::memcpy(SendBuffer.get(), DataPtr, DataLength);
@@ -29,7 +40,8 @@ void TestUDPServer::startPacketTransmission(int TotalPackets, int PacketGapNS) {
   NrOfPackets = TotalPackets;
   WaitTimeNSec = PacketGapNS;
   asio::ip::udp::resolver::query Query(asio::ip::udp::v4(), "localhost", std::to_string(DestinationPort));
-  Resolver.async_resolve(Query, std::bind(&TestUDPServer::handleResolve, this, std::placeholders::_1, std::placeholders::_2));
+  Resolver.async_resolve(Query,
+                         std::bind(&TestUDPServer::handleResolve, this, std::placeholders::_1, std::placeholders::_2));
   AsioThread = std::thread(&TestUDPServer::threadFunction, this);
 }
 
@@ -49,7 +61,8 @@ void TestUDPServer::threadFunction() {
   Service.run();
 }
 
-void TestUDPServer::handleResolve(const asio::error_code __attribute__((unused)) &Err, asio::ip::udp::resolver::iterator EndpointIter) {
+void TestUDPServer::handleResolve(const asio::error_code __attribute__((unused)) &Err,
+                                  asio::ip::udp::resolver::iterator EndpointIter) {
   asio::ip::udp::endpoint Endpoint = *EndpointIter;
   Socket.async_connect(Endpoint, std::bind(&TestUDPServer::handleConnect, this, std::placeholders::_1, ++EndpointIter));
 }
@@ -57,25 +70,25 @@ void TestUDPServer::handleResolve(const asio::error_code __attribute__((unused))
 void TestUDPServer::handleConnect(const asio::error_code &Err,
                                   asio::ip::udp::resolver::iterator EndpointIter) {
   if (!Err) {
-    Socket.async_send(asio::buffer(SendBuffer.get(), BufferSize), std::bind(&TestUDPServer::handleWrite, this, std::placeholders::_1, std::placeholders::_2));
+    Socket.async_send(asio::buffer(SendBuffer.get(), BufferSize),
+                      std::bind(&TestUDPServer::handleWrite, this, std::placeholders::_1, std::placeholders::_2));
     --NrOfPackets;
     PacketTimer.expires_from_now(std::chrono::nanoseconds(WaitTimeNSec));
     PacketTimer.async_wait(std::bind(&TestUDPServer::handleNewPacket, this, std::placeholders::_1));
-  }
-  else if (EndpointIter != asio::ip::udp::resolver::iterator())
-  {
+  } else if (EndpointIter != asio::ip::udp::resolver::iterator()) {
     Socket.close();
     asio::ip::udp::endpoint Endpoint = *EndpointIter;
     Socket.async_connect(Endpoint,
-                          std::bind(&TestUDPServer::handleConnect, this,
-                                      std::placeholders::_1, ++EndpointIter));
+                         std::bind(&TestUDPServer::handleConnect, this,
+                                   std::placeholders::_1, ++EndpointIter));
   }
 }
 
 void TestUDPServer::handleNewPacket(const asio::error_code &Err) {
   if (!Err and NrOfPackets > 0 and not GotError) {
     --NrOfPackets;
-    Socket.async_send(asio::buffer(SendBuffer.get(), BufferSize), std::bind(&TestUDPServer::handleWrite, this, std::placeholders::_1, std::placeholders::_2));
+    Socket.async_send(asio::buffer(SendBuffer.get(), BufferSize),
+                      std::bind(&TestUDPServer::handleWrite, this, std::placeholders::_1, std::placeholders::_2));
     PacketTimer.expires_from_now(std::chrono::nanoseconds(WaitTimeNSec));
     PacketTimer.async_wait(std::bind(&TestUDPServer::handleNewPacket, this, std::placeholders::_1));
   }

--- a/prototype2/adc_readout/test/TestUDPServer.h
+++ b/prototype2/adc_readout/test/TestUDPServer.h
@@ -28,8 +28,8 @@ public:
   ~TestUDPServer();
 
 private:
-  std::uint16_t SourcePort, DestinationPort;
   asio::io_service Service;
+  std::uint16_t SourcePort, DestinationPort;
   void threadFunction();
   std::thread AsioThread;
   asio::ip::udp::socket Socket;

--- a/prototype2/efu/CMakeLists.txt
+++ b/prototype2/efu/CMakeLists.txt
@@ -21,7 +21,6 @@ set(efu_INC
   Server.h
   )
   
-add_definitions(-std=c++11)
 create_executable(efu)
 get_filename_component(EFU_RUN_INSTRUCTIONS "Executing artefacts.md" ABSOLUTE)
 add_custom_command(TARGET efu POST_BUILD

--- a/prototype2/multigrid/mgmesytec/DataParserTest.cpp
+++ b/prototype2/multigrid/mgmesytec/DataParserTest.cpp
@@ -10,7 +10,11 @@ static Producer producer {"noserver", "nostream"};
 class MesytecDataTest : public TestBase {
 protected:
   NMXHists hists;
-  MesytecData mesytec{0, "nofile", 1}; // Dont dumptofile select module with 20 depth in z
+#ifdef DUMPTOFILE
+MesytecData mesytec{0, "nofile", 1}; // Dont dumptofile select module with 20 depth in z
+#else
+MesytecData mesytec {1}; // Dont dumptofile select module with 20 depth in z
+#endif
   ReadoutSerializer * serializer;
   FBSerializer * fbserializer;
   virtual void SetUp() {


### PR DESCRIPTION
I have switched over to Ubuntu 18.04 LTS on my PC. In the long run, we will drop support for the the non-LTS versions, and very likely 16.04 as well. Compiling with whatever the default gcc is on this system produced some errors.
Fixed the following:
1) Warnings about order of initialization
2) Fragile linking of unit tests for adc readout
3) Mesytec tests not building without DUMPTOFILE
4) Some redundant CMake stuff I found
