### PR TITLE
Conan from within CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,11 @@ add_subdirectory(dataformats)
 
 # Should unit_test_targets depend on default targets ???
 
+add_custom_target(unit_tests
+  DEPENDS ${unit_test_targets})
 add_custom_target(runtest
     COMMAND ${CMAKE_CTEST_COMMAND} -V -R regular_*
-    DEPENDS ${unit_test_targets})
+    DEPENDS ${unit_tests})
 add_custom_target(valgrind
     DEPENDS ${valgrind_targets})
 add_custom_target(benchmark

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ add_custom_target(unit_tests
   DEPENDS ${unit_test_targets})
 add_custom_target(runtest
     COMMAND ${CMAKE_CTEST_COMMAND} -V -R regular_*
-    DEPENDS ${unit_tests})
+    DEPENDS unit_tests)
 add_custom_target(valgrind
     DEPENDS ${valgrind_targets})
 add_custom_target(benchmark

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,27 @@ set(EXTRA_MODULES_DIR ${CMAKE_CURRENT_LIST_DIR}/cmake)
 list(APPEND CMAKE_MODULE_PATH ${EXTRA_MODULES_DIR}/modules)
 
 #=============================================================================
-# If conan has generated info, use it now
+# Conan
 #=============================================================================
-if(EXISTS ${PROJECT_BINARY_DIR}/conanbuildinfo.cmake)
-  message(STATUS "Using existing conanbuildinfo.cmake file")
-  include(${PROJECT_BINARY_DIR}/conanbuildinfo.cmake)
-  conan_basic_setup(KEEP_RPATHS)
+
+SET(CONAN_PROFILE "default" CACHE STRING "Name of conan profile to use, uses default by default")
+SET(CONAN "AUTO" CACHE STRING "conan options AUTO (conan must be in path), MANUAL (expects conanbuildinfo.cmake in build directory) or DISABLE")
+if(${CONAN} MATCHES "AUTO")
+  include(${CMAKE_MODULE_PATH}/conan.cmake)
+  conan_cmake_run(CONANFILE conanfile.txt
+      PROFILE ${CONAN_PROFILE}
+      BASIC_SETUP NO_OUTPUT_DIRS SKIP_RPATH
+      BUILD_TYPE "None"
+      BUILD outdated)
+elseif(${CONAN} MATCHES "MANUAL")
+  if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    conan_basic_setup(NO_OUTPUT_DIRS SKIP_RPATH)
+  else()
+    MESSAGE(FATAL_ERROR "CONAN set to MANUAL but no file named conanbuildinfo.cmake found in build directory")
+  endif()
+elseif(NOT ${CONAN} MATCHES "DISABLE")
+  MESSAGE(FATAL_ERROR "Unrecognised option for CONAN (${CONAN}), use AUTO, MANUAL or DISABLE")
 endif()
 
 #=============================================================================
@@ -60,8 +75,6 @@ add_custom_target(valgrind
     DEPENDS ${valgrind_targets})
 add_custom_target(benchmark
     DEPENDS ${benchmark_targets})
-
-message(STATUS "targets= ${BUILDSYSTEM_TARGETS}")
 
 #=============================================================================
 # Finalize coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(${CONAN} MATCHES "AUTO")
   include(${CMAKE_MODULE_PATH}/conan.cmake)
   conan_cmake_run(CONANFILE conanfile.txt
       PROFILE ${CONAN_PROFILE}
-      BASIC_SETUP NO_OUTPUT_DIRS SKIP_RPATH
+      BASIC_SETUP NO_OUTPUT_DIRS KEEP_RPATHS
       BUILD_TYPE "None"
       BUILD outdated)
 elseif(${CONAN} MATCHES "MANUAL")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,6 +211,7 @@ def get_macos_pipeline()
                     sh "cmake -DCONAN=MANUAL -DDUMPTOFILE=ON -DCMAKE_MACOSX_RPATH=ON ../code"
                     sh "make"
                     sh "make runtest"
+                    sh "make runefu"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,7 @@ def docker_tests_coverage(image_key) {
                 . ./activate_run.sh
                 make runefu
                 make coverage
-                make valgrind
+                make -j4 valgrind
             \""""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/${project} ./"
     } catch(e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,6 +103,7 @@ def docker_build(image_key) {
         cd ${project}/build
         make --version
         make -j4 VERBOSE=ON
+        make -j4 unit_tests VERBOSE=ON
     \""""
 }
 
@@ -111,8 +112,8 @@ def docker_tests(image_key) {
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         cd ${project}/build
         . ./activate_run.sh
-        make -j4 runtest VERBOSE=ON
-        make runefu VERBOSE=ON
+        make runtest
+        make runefu
     \""""
 }
 
@@ -124,9 +125,9 @@ def docker_tests_coverage(image_key) {
         sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
                 cd ${project}/build
                 . ./activate_run.sh
-                make runefu VERBOSE=ON
-                make coverage VERBOSE=ON
-                make valgrind VERBOSE=ON
+                make runefu
+                make coverage
+                make valgrind
             \""""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/${project} ./"
     } catch(e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,7 +238,8 @@ def get_macos_pipeline()
                     sh "conan install --build=outdated ../code"
                     sh "cmake -DCONAN=MANUAL -DDUMPTOFILE=ON -DCMAKE_MACOSX_RPATH=ON ../code"
                     sh "make -j4"
-                    sh "make -j4 runtest"
+                    sh "make -j4 unit_tests"
+                    sh "make runtest"
                     sh "make runefu"
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ def docker_cmake(image_key, xtra_flags) {
 //        ${cmake_exec} --version
 //        ${cmake_exec} -DCONAN=MANUAL ${xtra_flags} ..
 //    \""""
-    sh """docker exec ${container_name} ${custom_sh} -c \"
+    sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
                         cd ${project} && \
                         BUILDSTR=\\\$(git log --oneline | head -n 1 | awk '{print \\\$1}') && \
                         cd build && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,6 +91,7 @@ def docker_build(image_key) {
     def custom_sh = images[image_key]['sh']
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         cd ${project}/build
+        . ./activate_run.sh
         make --version
         make VERBOSE=ON
     \""""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,9 +199,7 @@ def get_pipeline(image_key)
 
                     docker_clone(image_key)
                     docker_dependencies(image_key)
-
                     docker_cmake(image_key, images[image_key]['cmake_flags'])
-
                     docker_build(image_key)
 
                     if (image_key == coverage_on) {
@@ -237,7 +235,7 @@ def get_macos_pipeline()
 
                 dir("${project}/build") {
                     sh "conan install --build=outdated ../code"
-                    sh "cmake -DDUMPTOFILE=ON -DCMAKE_MACOSX_RPATH=ON ../code"
+                    sh "cmake -DCONAN=MANUAL -DDUMPTOFILE=ON -DCMAKE_MACOSX_RPATH=ON ../code"
                     sh "make -j4"
                     sh "make -j4 runtest"
                     sh "make runefu"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,6 @@ def docker_dependencies(image_key) {
         conan remote add \
             --insert 0 \
             ${conan_remote} ${local_conan_server}
-        conan install --build=outdated ..
     \""""
 }
 
@@ -83,7 +82,6 @@ def docker_cmake(image_key, xtra_flags) {
     def custom_sh = images[image_key]['sh']
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         cd ${project}/build
-        . ./activate_run.sh
         ${cmake_exec} --version
         ${cmake_exec} ${xtra_flags} ..
     \""""
@@ -207,7 +205,6 @@ def get_macos_pipeline()
                 }
 
                 dir("${project}/build") {
-                    sh "conan install --build=outdated ../code"
                     sh "cmake -DDUMPTOFILE=ON -DCMAKE_MACOSX_RPATH=ON ../code"
                     sh "make"
                     sh "make runtest"
@@ -253,14 +250,12 @@ def get_release_pipeline()
                         conan remote add \
                             --insert 0 \
                             ${conan_remote} ${local_conan_server} && \
-                        conan install --build=outdated ../${project}
                     \""""
 
                     sh """docker exec ${container_name} ${custom_sh} -c \"
                         cd ${project} && \
                         BUILDSTR=\\\$(git log --oneline | head -n 1 | awk '{print \\\$1}') && \
                         cd ../build && \
-                        . ./activate_run.sh && \
                         cmake --version && \
                         cmake \
                             -DCMAKE_BUILD_TYPE=Release \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,6 +175,7 @@ def docker_archive(image_key) {
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
                         mkdir -p archive/event-formation-unit && \
                         cp -r ${project}/build/bin archive/event-formation-unit && \
+                        cp -r ${project}/build/modules archive/event-formation-unit && \
                         cp -r ${project}/build/lib archive/event-formation-unit && \
                         cp -r ${project}/build/licenses archive/event-formation-unit && \
                         mkdir archive/event-formation-unit/util && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ def docker_build(image_key) {
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         cd ${project}/build
         make --version
-        make VERBOSE=ON
+        make -j4 VERBOSE=ON
     \""""
 }
 
@@ -111,7 +111,7 @@ def docker_tests(image_key) {
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         cd ${project}/build
         . ./activate_run.sh
-        make runtest VERBOSE=ON
+        make -j4 runtest VERBOSE=ON
         make runefu VERBOSE=ON
     \""""
 }
@@ -124,7 +124,6 @@ def docker_tests_coverage(image_key) {
         sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
                 cd ${project}/build
                 . ./activate_run.sh
-                make VERBOSE=ON
                 make runefu VERBOSE=ON
                 make coverage VERBOSE=ON
                 make valgrind VERBOSE=ON
@@ -239,8 +238,8 @@ def get_macos_pipeline()
                 dir("${project}/build") {
                     sh "conan install --build=outdated ../code"
                     sh "cmake -DDUMPTOFILE=ON -DCMAKE_MACOSX_RPATH=ON ../code"
-                    sh "make"
-                    sh "make runtest"
+                    sh "make -j4"
+                    sh "make -j4 runtest"
                     sh "make runefu"
                 }
             }
@@ -281,7 +280,6 @@ node('docker') {
         builders[image_key] = get_pipeline(image_key)
     }
     builders['macOS'] = get_macos_pipeline()
-//    builders['release-centos7'] = get_release_pipeline()
 
     try {
         parallel builders

--- a/README.md
+++ b/README.md
@@ -87,10 +87,6 @@ mkdir build
 
 cd build
 
-conan install --build=outdated ..
-
-source activate_run.sh
-
 cmake ..
 
 make
@@ -150,13 +146,6 @@ Wen using conan to provide the dependencies, an extra option has to be provided:
 ```bash
 conan install --build=outdated .. --settings compiler.libcxx=libstdc++11
 ```
-
-You will also need to force the EFU build system to use the correct flags by adding `-DUSE_OLD_ABI=0`. I.e, when running CMake, run it as follows:
-
-```bash
-cmake .. -DUSE_OLD_ABI=0
-```
-Installing the dependencies manually has been tested under Ubuntu and this appears to be generally working. Note however that you will need to run CMake with the ``-DUSE_OLD_ABI=0`` argument in this case as well.
 
 ## Targets and options
 See options and targets by

--- a/Utilities.cmake
+++ b/Utilities.cmake
@@ -16,7 +16,7 @@ function(create_module module_name)
   endif()
 
   set_target_properties(${module_name} PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/modules")
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/modules")
 
   enable_coverage(${module_name})
   install(TARGETS ${module_name} DESTINATION bin)

--- a/Utilities.cmake
+++ b/Utilities.cmake
@@ -71,6 +71,9 @@ function(create_test_executable)
     add_linker_flags(${exec_name} "-Wl,--no-as-needed")
   endif()
 
+  set_target_properties(${exec_name} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/unit_tests")
+
   add_test(NAME regular_${exec_name}
     COMMAND ${exec_name}
     "--gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${exec_name}test.xml")
@@ -81,7 +84,7 @@ function(create_test_executable)
 
   enable_coverage(${exec_name})
   if(NOT ${create_test_executable_SKIP_MEMGRIND})
-    memcheck_test(${exec_name} ${CMAKE_BINARY_DIR}/bin)
+    memcheck_test(${exec_name} ${CMAKE_BINARY_DIR}/unit_tests)
   endif()
 endfunction(create_test_executable)
 

--- a/Utilities.cmake
+++ b/Utilities.cmake
@@ -63,9 +63,9 @@ function(create_test_executable exec_name)
     ${EFU_COMMON_LIBS}
     ${GTEST_LIBRARIES})
 
-  if(${CMAKE_COMPILER_IS_GNUCXX})
-    add_linker_flags(${exec_name} "-Wl,--no-as-needed")
-  endif()
+#  if(${CMAKE_COMPILER_IS_GNUCXX})
+#    add_linker_flags(${exec_name} "-Wl,--no-as-needed")
+#  endif()
 
   add_test(NAME regular_${exec_name}
     COMMAND ${exec_name}
@@ -76,7 +76,7 @@ function(create_test_executable exec_name)
     CACHE INTERNAL "All test targets")
 
   enable_coverage(${exec_name})
-  memcheck_test(${exec_name} ${CMAKE_BINARY_DIR}/bin)
+  memcheck_test(${exec_name} ${CMAKE_BINARY_DIR}/unit_tests)
 endfunction(create_test_executable)
 
 function(create_integration_test_executable exec_name)

--- a/Utilities.cmake
+++ b/Utilities.cmake
@@ -48,7 +48,7 @@ endfunction(create_executable)
 #=============================================================================
 set(unit_test_targets "" CACHE INTERNAL "All test targets")
 
-function(create_test_executable exec_name)
+function(create_leaky_test_executable exec_name)
   add_executable(${exec_name} EXCLUDE_FROM_ALL
     ${${exec_name}_SRC}
     ${${exec_name}_INC})
@@ -72,6 +72,10 @@ function(create_test_executable exec_name)
     CACHE INTERNAL "All test targets")
 
   enable_coverage(${exec_name})
+endfunction(create_leaky_test_executable)
+
+function(create_test_executable exec_name)
+  create_leaky_test_executable(${exec_name})
   memcheck_test(${exec_name} ${CMAKE_BINARY_DIR}/unit_tests)
 endfunction(create_test_executable)
 

--- a/Utilities.cmake
+++ b/Utilities.cmake
@@ -63,10 +63,6 @@ function(create_test_executable exec_name)
     ${EFU_COMMON_LIBS}
     ${GTEST_LIBRARIES})
 
-#  if(${CMAKE_COMPILER_IS_GNUCXX})
-#    add_linker_flags(${exec_name} "-Wl,--no-as-needed")
-#  endif()
-
   add_test(NAME regular_${exec_name}
     COMMAND ${exec_name}
     "--gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${exec_name}test.xml")
@@ -93,10 +89,5 @@ function(create_integration_test_executable exec_name)
     ${${exec_name}_LIB}
     ${EFU_COMMON_LIBS}
     eventlib)
-
-#  if(${CMAKE_COMPILER_IS_GNUCXX})
-#    add_linker_flags(${exec_name} "-Wl,--no-as-needed")
-#  endif()
-
 endfunction(create_integration_test_executable)
 

--- a/Utilities.cmake
+++ b/Utilities.cmake
@@ -14,6 +14,10 @@ function(create_module module_name)
   if(${CMAKE_COMPILER_IS_GNUCXX})
     add_linker_flags(${module_name} "-Wl,--no-as-needed")
   endif()
+
+  set_target_properties(${module_name} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/modules")
+
   enable_coverage(${module_name})
   install(TARGETS ${module_name} DESTINATION bin)
 endfunction(create_module)
@@ -30,6 +34,10 @@ function(create_executable exec_name)
     ${${exec_name}_LIB}
     ${EFU_COMMON_LIBS}
     eventlib)
+
+  set_target_properties(${exec_name} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
   enable_coverage(${exec_name})
   install(TARGETS ${exec_name} DESTINATION bin)
 endfunction(create_executable)
@@ -47,9 +55,8 @@ function(create_test_executable exec_name)
   target_include_directories(${exec_name}
     PRIVATE ${GTEST_INCLUDE_DIRS})
 
-  # This does not seem to work right now. Conan to blame ???
-  #  set_target_properties(${exec_name} PROPERTIES
-  #    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/unit_tests")
+  set_target_properties(${exec_name} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/unit_tests")
 
   target_link_libraries(${exec_name}
     ${${exec_name}_LIB}
@@ -70,6 +77,26 @@ function(create_test_executable exec_name)
 
   enable_coverage(${exec_name})
   memcheck_test(${exec_name} ${CMAKE_BINARY_DIR}/bin)
-
 endfunction(create_test_executable)
+
+function(create_integration_test_executable exec_name)
+  add_executable(${exec_name} EXCLUDE_FROM_ALL
+    ${${exec_name}_SRC}
+    ${${exec_name}_INC})
+  target_include_directories(${exec_name}
+    PRIVATE ${GTEST_INCLUDE_DIRS})
+
+  set_target_properties(${exec_name} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/integration_tests")
+
+  target_link_libraries(${exec_name}
+    ${${exec_name}_LIB}
+    ${EFU_COMMON_LIBS}
+    eventlib)
+
+#  if(${CMAKE_COMPILER_IS_GNUCXX})
+#    add_linker_flags(${exec_name} "-Wl,--no-as-needed")
+#  endif()
+
+endfunction(create_integration_test_executable)
 

--- a/cmake/modules/conan.cmake
+++ b/cmake/modules/conan.cmake
@@ -1,0 +1,417 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2018 JFrog
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+
+# This file comes from: https://github.com/conan-io/cmake-conan. Please refer
+# to this repository for issues and documentation.
+
+# Its purpose is to wrap and launch Conan C/C++ Package Manager when cmake is called.
+# It will take CMake current settings (os, compiler, compiler version, architecture)
+# and translate them to conan settings for installing and retrieving dependencies.
+
+# It is intended to facilitate developers building projects that have conan dependencies,
+# but it is only necessary on the end-user side. It is not necessary to create conan
+# packages, in fact it shouldn't be use for that. Check the project documentation.
+
+
+include(CMakeParseArguments)
+
+function(_get_msvc_ide_version result)
+    set(${result} "" PARENT_SCOPE)
+    if(NOT MSVC_VERSION VERSION_LESS 1400 AND MSVC_VERSION VERSION_LESS 1500)
+        set(${result} 8 PARENT_SCOPE)
+    elseif(NOT MSVC_VERSION VERSION_LESS 1500 AND MSVC_VERSION VERSION_LESS 1600)
+        set(${result} 9 PARENT_SCOPE)
+    elseif(NOT MSVC_VERSION VERSION_LESS 1600 AND MSVC_VERSION VERSION_LESS 1700)
+        set(${result} 10 PARENT_SCOPE)
+    elseif(NOT MSVC_VERSION VERSION_LESS 1700 AND MSVC_VERSION VERSION_LESS 1800)
+        set(${result} 11 PARENT_SCOPE)
+    elseif(NOT MSVC_VERSION VERSION_LESS 1800 AND MSVC_VERSION VERSION_LESS 1900)
+        set(${result} 12 PARENT_SCOPE)
+    elseif(NOT MSVC_VERSION VERSION_LESS 1900 AND MSVC_VERSION VERSION_LESS 1910)
+        set(${result} 14 PARENT_SCOPE)
+    elseif(NOT MSVC_VERSION VERSION_LESS 1910 AND MSVC_VERSION VERSION_LESS 1920)
+        set(${result} 15 PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Conan: Unknown MSVC compiler version [${MSVC_VERSION}]")
+    endif()
+endfunction()
+
+function(conan_cmake_settings result)
+    #message(STATUS "COMPILER " ${CMAKE_CXX_COMPILER})
+    #message(STATUS "COMPILER " ${CMAKE_CXX_COMPILER_ID})
+    #message(STATUS "VERSION " ${CMAKE_CXX_COMPILER_VERSION})
+    #message(STATUS "FLAGS " ${CMAKE_LANG_FLAGS})
+    #message(STATUS "LIB ARCH " ${CMAKE_CXX_LIBRARY_ARCHITECTURE})
+    #message(STATUS "BUILD TYPE " ${CMAKE_BUILD_TYPE})
+    #message(STATUS "GENERATOR " ${CMAKE_GENERATOR})
+    #message(STATUS "GENERATOR WIN64 " ${CMAKE_CL_64})
+
+    message(STATUS "Conan ** WARNING** : This detection of settings from cmake is experimental and incomplete. "
+            "Please check 'conan.cmake' and contribute")
+
+    parse_arguments(${ARGV})
+    set(arch ${ARGUMENTS_ARCH})
+
+    if(CONAN_CMAKE_MULTI)
+        set(_SETTINGS -g cmake_multi)
+    else()
+        set(_SETTINGS -g cmake)
+    endif()
+    if(ARGUMENTS_BUILD_TYPE)
+        set(_SETTINGS ${_SETTINGS} -s build_type=${ARGUMENTS_BUILD_TYPE})
+    elseif(CMAKE_BUILD_TYPE)
+        set(_SETTINGS ${_SETTINGS} -s build_type=${CMAKE_BUILD_TYPE})
+    else()
+        message(FATAL_ERROR "Please specify in command line CMAKE_BUILD_TYPE (-DCMAKE_BUILD_TYPE=Release)")
+    endif()
+
+    #handle -s os setting
+    if(CMAKE_SYSTEM_NAME)
+        #use default conan os setting if CMAKE_SYSTEM_NAME is not defined
+        set(CONAN_SYSTEM_NAME ${CMAKE_SYSTEM_NAME})
+        if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+            set(CONAN_SYSTEM_NAME Macos)
+        endif()
+        set(CONAN_SUPPORTED_PLATFORMS Windows Linux Macos Android iOS FreeBSD)
+        list (FIND CONAN_SUPPORTED_PLATFORMS "${CONAN_SYSTEM_NAME}" _index)
+        if (${_index} GREATER -1)
+            #check if the cmake system is a conan supported one
+            set(_SETTINGS ${_SETTINGS} -s os=${CONAN_SYSTEM_NAME})
+        else()
+            message(FATAL_ERROR "cmake system ${CONAN_SYSTEM_NAME} is not supported by conan. Use one of ${CONAN_SUPPORTED_PLATFORMS}")
+        endif()
+    endif()
+
+    get_property(_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+    if (";${_languages};" MATCHES ";CXX;")
+        set(LANGUAGE CXX)
+        set(USING_CXX 1)
+    elseif (";${_languages};" MATCHES ";C;")
+        set(LANGUAGE C)
+        set(USING_CXX 0)
+    else ()
+        message(FATAL_ERROR "Conan: Neither C or C++ was detected as a language for the project. Unabled to detect compiler version.")
+    endif()
+
+    if(arch)
+        set(_SETTINGS ${_SETTINGS} -s arch=${arch})
+    endif()
+
+    if (${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL GNU)
+        # using GCC
+        # TODO: Handle other params
+        string(REPLACE "." ";" VERSION_LIST ${CMAKE_${LANGUAGE}_COMPILER_VERSION})
+        list(GET VERSION_LIST 0 MAJOR)
+        list(GET VERSION_LIST 1 MINOR)
+        set(COMPILER_VERSION ${MAJOR}.${MINOR})
+        if(${MAJOR} GREATER 4)
+            set(COMPILER_VERSION ${MAJOR})
+        endif()
+        set(_SETTINGS ${_SETTINGS} -s compiler=gcc -s compiler.version=${COMPILER_VERSION})
+        if (USING_CXX)
+            conan_cmake_detect_gnu_libcxx(_LIBCXX)
+            set(_SETTINGS ${_SETTINGS} -s compiler.libcxx=${_LIBCXX})
+        endif ()
+    elseif (${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL AppleClang)
+        # using AppleClang
+        string(REPLACE "." ";" VERSION_LIST ${CMAKE_${LANGUAGE}_COMPILER_VERSION})
+        list(GET VERSION_LIST 0 MAJOR)
+        list(GET VERSION_LIST 1 MINOR)
+        set(_SETTINGS ${_SETTINGS} -s compiler=apple-clang -s compiler.version=${MAJOR}.${MINOR})
+        if (USING_CXX)
+            set(_SETTINGS ${_SETTINGS} -s compiler.libcxx=libc++)
+        endif ()
+    elseif (${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL Clang)
+        string(REPLACE "." ";" VERSION_LIST ${CMAKE_${LANGUAGE}_COMPILER_VERSION})
+        list(GET VERSION_LIST 0 MAJOR)
+        list(GET VERSION_LIST 1 MINOR)
+        if(APPLE)
+            cmake_policy(GET CMP0025 APPLE_CLANG_POLICY_ENABLED)
+            if(NOT APPLE_CLANG_POLICY_ENABLED)
+                message(STATUS "Conan: APPLE and Clang detected. Assuming apple-clang compiler. Set CMP0025 to avoid it")
+                set(_SETTINGS ${_SETTINGS} -s compiler=apple-clang -s compiler.version=${MAJOR}.${MINOR})
+            else()
+                set(_SETTINGS ${_SETTINGS} -s compiler=clang -s compiler.version=${MAJOR}.${MINOR})
+            endif()
+            if (USING_CXX)
+                set(_SETTINGS ${_SETTINGS} -s compiler.libcxx=libc++)
+            endif ()
+        else()
+            set(_SETTINGS ${_SETTINGS} -s compiler=clang -s compiler.version=${MAJOR}.${MINOR})
+            if (USING_CXX)
+                conan_cmake_detect_gnu_libcxx(_LIBCXX)
+                set(_SETTINGS ${_SETTINGS} -s compiler.libcxx=${_LIBCXX})
+            endif ()
+        endif()
+    elseif(${CMAKE_${LANGUAGE}_COMPILER_ID} STREQUAL MSVC)
+        set(_VISUAL "Visual Studio")
+        _get_msvc_ide_version(_VISUAL_VERSION)
+        if("${_VISUAL_VERSION}" STREQUAL "")
+            message(FATAL_ERROR "Conan: Visual Studio not recognized")
+        else()
+            set(_SETTINGS ${_SETTINGS} -s compiler=${_VISUAL} -s compiler.version=${_VISUAL_VERSION})
+        endif()
+
+        if(NOT arch)
+            if (MSVC_${LANGUAGE}_ARCHITECTURE_ID MATCHES "64")
+                set(_SETTINGS ${_SETTINGS} -s arch=x86_64)
+            elseif (MSVC_${LANGUAGE}_ARCHITECTURE_ID MATCHES "^ARM")
+                message(STATUS "Conan: Using default ARM architecture from MSVC")
+                set(_SETTINGS ${_SETTINGS} -s arch=armv6)
+            elseif (MSVC_${LANGUAGE}_ARCHITECTURE_ID MATCHES "86")
+                set(_SETTINGS ${_SETTINGS} -s arch=x86)
+            else ()
+                message(FATAL_ERROR "Conan: Unknown MSVC architecture [${MSVC_${LANGUAGE}_ARCHITECTURE_ID}]")
+            endif()
+        endif()
+
+        conan_cmake_detect_vs_runtime(_vs_runtime)
+        message(STATUS "Detected VS runtime: ${_vs_runtime}")
+        set(_SETTINGS ${_SETTINGS} -s compiler.runtime=${_vs_runtime})
+
+        if (CMAKE_GENERATOR_TOOLSET)
+            set(_SETTINGS ${_SETTINGS} -s compiler.toolset=${CMAKE_GENERATOR_TOOLSET})
+        elseif(CMAKE_VS_PLATFORM_TOOLSET AND (CMAKE_GENERATOR STREQUAL "Ninja"))
+            set(_SETTINGS ${_SETTINGS} -s compiler.toolset=${CMAKE_VS_PLATFORM_TOOLSET})
+        endif()
+    else()
+        message(FATAL_ERROR "Conan: compiler setup not recognized")
+    endif()
+
+    foreach(ARG ${ARGUMENTS_SETTINGS})
+        set(_SETTINGS ${_SETTINGS} -s ${ARG})
+    endforeach()
+
+    set(${result} ${_SETTINGS} PARENT_SCOPE)
+endfunction()
+
+
+function(conan_cmake_detect_gnu_libcxx result)
+    # Allow -D_GLIBCXX_USE_CXX11_ABI=ON/OFF as argument to cmake
+    if(DEFINED _GLIBCXX_USE_CXX11_ABI)
+        if(_GLIBCXX_USE_CXX11_ABI)
+            set(${result} libstdc++11 PARENT_SCOPE)
+            return()
+        else()
+            set(${result} libstdc++ PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+
+    # Check if there's any add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+    get_directory_property(defines DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMPILE_DEFINITIONS)
+    foreach(define ${defines})
+        if(define STREQUAL "_GLIBCXX_USE_CXX11_ABI=0")
+            set(${result} libstdc++ PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+
+    # Use C++11 stdlib as default if gcc is 5.1+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.1")
+        set(${result} libstdc++ PARENT_SCOPE)
+    else()
+        set(${result} libstdc++11 PARENT_SCOPE)
+    endif()
+endfunction()
+
+
+function(conan_cmake_detect_vs_runtime result)
+    string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
+    set(variables CMAKE_CXX_FLAGS_${build_type} CMAKE_C_FLAGS_${build_type} CMAKE_CXX_FLAGS CMAKE_C_FLAGS)
+    foreach(variable ${variables})
+        string(REPLACE " " ";" flags ${${variable}})
+        foreach (flag ${flags})
+            if(${flag} STREQUAL "/MD" OR ${flag} STREQUAL "/MDd" OR ${flag} STREQUAL "/MT" OR ${flag} STREQUAL "/MTd")
+                string(SUBSTRING ${flag} 1 -1 runtime)
+                set(${result} ${runtime} PARENT_SCOPE)
+                return()
+            endif()
+        endforeach()
+    endforeach()
+    if(${build_type} STREQUAL "DEBUG")
+        set(${result} "MDd" PARENT_SCOPE)
+    else()
+        set(${result} "MD" PARENT_SCOPE)
+    endif()
+endfunction()
+
+
+macro(parse_arguments)
+    set(options BASIC_SETUP CMAKE_TARGETS UPDATE KEEP_RPATHS NO_OUTPUT_DIRS)
+    set(oneValueArgs CONANFILE DEBUG_PROFILE RELEASE_PROFILE PROFILE ARCH BUILD_TYPE)
+    set(multiValueArgs REQUIRES OPTIONS IMPORTS SETTINGS BUILD CONAN_COMMAND)
+    cmake_parse_arguments(ARGUMENTS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+endmacro()
+
+function(conan_cmake_install)
+    # Calls "conan install"
+    # Argument BUILD is equivalant to --build={missing, PkgName,...} or
+    # --build when argument is 'BUILD all' (which builds all packages from source)
+    # Argument CONAN_COMMAND, to specify the conan path, e.g. in case of running from source
+    # cmake does not identify conan as command, even if it is +x and it is in the path
+    parse_arguments(${ARGV})
+
+    set(CONAN_BUILD_POLICY "")
+    foreach(ARG ${ARGUMENTS_BUILD})
+        if(${ARG} STREQUAL "all")
+            set(CONAN_BUILD_POLICY ${CONAN_BUILD_POLICY} --build)
+            break()
+        else()
+            set(CONAN_BUILD_POLICY ${CONAN_BUILD_POLICY} --build=${ARG})
+        endif()
+    endforeach()
+    if(ARGUMENTS_CONAN_COMMAND)
+        set(conan_command ${ARGUMENTS_CONAN_COMMAND})
+    else()
+        set(conan_command conan)
+    endif()
+    set(CONAN_OPTIONS "")
+    if(ARGUMENTS_CONANFILE)
+        set(CONANFILE ${CMAKE_CURRENT_SOURCE_DIR}/${ARGUMENTS_CONANFILE})
+        # A conan file has been specified - apply specified options as well if provided
+        foreach(ARG ${ARGUMENTS_OPTIONS})
+            set(CONAN_OPTIONS ${CONAN_OPTIONS} -o ${ARG})
+        endforeach()
+    else()
+        set(CONANFILE ".")
+    endif()
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND ARGUMENTS_DEBUG_PROFILE)
+        set(settings -pr ${ARGUMENTS_DEBUG_PROFILE})
+    endif()
+    if(CMAKE_BUILD_TYPE STREQUAL "Release" AND ARGUMENTS_RELEASE_PROFILE)
+        set(settings -pr ${ARGUMENTS_RELEASE_PROFILE})
+    endif()
+    if(ARGUMENTS_PROFILE)
+        set(settings -pr ${ARGUMENTS_PROFILE})
+    endif()
+    if(ARGUMENTS_UPDATE)
+        set(CONAN_INSTALL_UPDATE --update)
+    endif()
+    set(conan_args install ${CONANFILE} ${settings} ${CONAN_BUILD_POLICY} ${CONAN_INSTALL_UPDATE} ${CONAN_OPTIONS})
+
+    string (REPLACE ";" " " _conan_args "${conan_args}")
+    message(STATUS "Conan executing: ${conan_command} ${_conan_args}")
+
+    execute_process(COMMAND ${conan_command} ${conan_args}
+            RESULT_VARIABLE return_code
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    if(NOT "${return_code}" STREQUAL "0")
+        message(FATAL_ERROR "Conan install failed='${return_code}'")
+    endif()
+
+endfunction()
+
+
+function(conan_cmake_setup_conanfile)
+    parse_arguments(${ARGV})
+    if(ARGUMENTS_CONANFILE)
+        # configure_file will make sure cmake re-runs when conanfile is updated
+        configure_file(${ARGUMENTS_CONANFILE} ${ARGUMENTS_CONANFILE}.junk)
+        file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${ARGUMENTS_CONANFILE}.junk)
+    else()
+        conan_cmake_generate_conanfile(${ARGV})
+    endif()
+endfunction()
+
+function(conan_cmake_generate_conanfile)
+    # Generate, writing in disk a conanfile.txt with the requires, options, and imports
+    # specified as arguments
+    # This will be considered as temporary file, generated in CMAKE_CURRENT_BINARY_DIR)
+    parse_arguments(${ARGV})
+    set(_FN "${CMAKE_CURRENT_BINARY_DIR}/conanfile.txt")
+
+    file(WRITE ${_FN} "[generators]\ncmake\n\n[requires]\n")
+    foreach(ARG ${ARGUMENTS_REQUIRES})
+        file(APPEND ${_FN} ${ARG} "\n")
+    endforeach()
+
+    file(APPEND ${_FN} ${ARG} "\n[options]\n")
+    foreach(ARG ${ARGUMENTS_OPTIONS})
+        file(APPEND ${_FN} ${ARG} "\n")
+    endforeach()
+
+    file(APPEND ${_FN} ${ARG} "\n[imports]\n")
+    foreach(ARG ${ARGUMENTS_IMPORTS})
+        file(APPEND ${_FN} ${ARG} "\n")
+    endforeach()
+endfunction()
+
+
+macro(conan_load_buildinfo)
+    if(CONAN_CMAKE_MULTI)
+        set(_CONANBUILDINFO conanbuildinfo_multi.cmake)
+    else()
+        set(_CONANBUILDINFO conanbuildinfo.cmake)
+    endif()
+    # Checks for the existence of conanbuildinfo.cmake, and loads it
+    # important that it is macro, so variables defined at parent scope
+    if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${_CONANBUILDINFO}")
+        message(STATUS "Conan: Loading ${_CONANBUILDINFO}")
+        include(${CMAKE_CURRENT_BINARY_DIR}/${_CONANBUILDINFO})
+    else()
+        message(FATAL_ERROR "${_CONANBUILDINFO} doesn't exist in ${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
+endmacro()
+
+
+macro(conan_cmake_run)
+    parse_arguments(${ARGV})
+
+    if(CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE AND NOT CONAN_EXPORTED)
+        set(CONAN_CMAKE_MULTI ON)
+        message(STATUS "Conan: Using cmake-multi generator")
+    else()
+        set(CONAN_CMAKE_MULTI OFF)
+    endif()
+    if(NOT CONAN_EXPORTED)
+        conan_cmake_setup_conanfile(${ARGV})
+        if(CONAN_CMAKE_MULTI)
+            foreach(CMAKE_BUILD_TYPE "Release" "Debug")
+                conan_cmake_settings(settings ${ARGV})
+                conan_cmake_install(SETTINGS ${settings} ${ARGV})
+            endforeach()
+            set(CMAKE_BUILD_TYPE)
+        else()
+            conan_cmake_settings(settings ${ARGV})
+            conan_cmake_install(SETTINGS ${settings} ${ARGV})
+        endif()
+    endif()
+
+    conan_load_buildinfo()
+
+    if(ARGUMENTS_BASIC_SETUP)
+        foreach(_option CMAKE_TARGETS KEEP_RPATHS NO_OUTPUT_DIRS)
+            if(ARGUMENTS_${_option})
+                if(${_option} STREQUAL "CMAKE_TARGETS")
+                    list(APPEND _setup_options "TARGETS")
+                else()
+                    list(APPEND _setup_options ${_option})
+                endif()
+            endif()
+        endforeach()
+        conan_basic_setup(${_setup_options})
+    endif()
+endmacro()

--- a/prototype2/CMakeLists.txt
+++ b/prototype2/CMakeLists.txt
@@ -63,7 +63,7 @@ add_subdirectory(udp)
 add_subdirectory(adc_readout)
 
 add_custom_target(runefu
-    COMMAND efu "-d" "../lib/mgmesytec" "-s" "1"
+    COMMAND efu "-d" "../bin/modules/mgmesytec" "-s" "1"
     DEPENDS efu mgmesytec
     )
 

--- a/prototype2/CMakeLists.txt
+++ b/prototype2/CMakeLists.txt
@@ -63,7 +63,7 @@ add_subdirectory(udp)
 add_subdirectory(adc_readout)
 
 add_custom_target(runefu
-    COMMAND efu "-d" "../bin/modules/mgmesytec" "-s" "1"
+    COMMAND efu "-d" "../modules/mgmesytec" "-s" "1"
     DEPENDS efu mgmesytec
     )
 

--- a/prototype2/CMakeLists.txt
+++ b/prototype2/CMakeLists.txt
@@ -30,21 +30,12 @@ set(EFU_COMMON_LIBS ${EFU_COMMON_LIBS}
 #=============================================================================
 # Optional external libraries
 #=============================================================================
-find_package(GraylogLogger)
-if(GraylogLogger_FOUND)
-  set(EFU_COMMON_LIBS ${EFU_COMMON_LIBS} ${GraylogLogger_STATIC_LIBRARIES})
-  add_definitions("-DGRAYLOG")
-else()
-  message(WARNING "GraylogLogger not found.")
-endif()
+find_package(GraylogLogger REQUIRED)
+set(EFU_COMMON_LIBS ${EFU_COMMON_LIBS} ${GraylogLogger_STATIC_LIBRARIES})
+add_definitions("-DGRAYLOG")
 
-find_package(h5cpp)
-if(h5cpp_FOUND)
-  set(EFU_COMMON_LIBS ${EFU_COMMON_LIBS} h5cpp ${HDF5_C_LIBRARIES} ${Boost_LIBRARIES})
-else()
-  message(WARNING "h5cpp not found.")
-endif()
-
+find_package(h5cpp REQUIRED)
+set(EFU_COMMON_LIBS ${EFU_COMMON_LIBS} h5cpp ${HDF5_C_LIBRARIES} ${Boost_LIBRARIES})
 
 #=============================================================================
 # Dependencies common to EFU and plugins

--- a/prototype2/adc_readout/CMakeLists.txt
+++ b/prototype2/adc_readout/CMakeLists.txt
@@ -62,7 +62,7 @@ set(AdcReadoutTest_LIB
 
 # Jonas has some reason for this
 # which he briefly explains here
-create_leaky_test_executable(AdcReadoutTest)
+create_test_executable(AdcReadoutTest SKIP_MEMGRIND)
 
 get_filename_component(TEST_PACKET_PATH "test/test_packet_1.dat" DIRECTORY)
 target_compile_definitions(AdcReadoutTest

--- a/prototype2/adc_readout/CMakeLists.txt
+++ b/prototype2/adc_readout/CMakeLists.txt
@@ -60,7 +60,9 @@ set(AdcReadoutTest_LIB
     eventlib
     )
 
-create_test_executable(AdcReadoutTest)
+# Jonas has some reason for this
+# which he briefly explains here
+create_leaky_test_executable(AdcReadoutTest)
 
 get_filename_component(TEST_PACKET_PATH "test/test_packet_1.dat" DIRECTORY)
 target_compile_definitions(AdcReadoutTest

--- a/prototype2/adc_readout/chopper_integration_test/CMakeLists.txt
+++ b/prototype2/adc_readout/chopper_integration_test/CMakeLists.txt
@@ -11,7 +11,7 @@ set(AdcChopperIntgerationTest_INC
   TDCGenerator.h
 )
 
-create_executable(AdcChopperIntgerationTest)
+create_integration_test_executable(AdcChopperIntgerationTest)
 target_include_directories(AdcChopperIntgerationTest PRIVATE "../")
 
 get_filename_component(ADC_CONFIG_FILE "AdcChopperIntegrationTestConfig.ini" ABSOLUTE)

--- a/prototype2/gdgem/CMakeLists.txt
+++ b/prototype2/gdgem/CMakeLists.txt
@@ -43,22 +43,18 @@ create_module(gdgem)
 # Data generators
 #=============================================================================
 
-if(h5cpp_FOUND)
-  set(gennmxfile_SRC
+set(gennmxfile_SRC
     nmx/Eventlet.cpp
     nmxgen/nmxfile.cpp
     nmxgen/NMXArgs.cpp
     nmxgen/ReaderVMM.cpp
     )
-  set(gennmxfile_INC
+set(gennmxfile_INC
     nmx/Eventlet.h
     nmxgen/NMXArgs.h
     nmxgen/ReaderVMM.h
     )
-  create_executable(gennmxfile)
-else()
-  message(STATUS "*** Unable to compile gennmxfile as h5cpp was not found.")
-endif()
+create_executable(gennmxfile)
 
 find_package(PCAP)
 if(PCAP_FOUND)


### PR DESCRIPTION
This uses the solution developed/adapted by @matthew-d-jones to run conan from within CMake. As a result, the `conan install ...` step can be skipped when building the software. This also means that you can run build steps without doing `./activate_run`. However, actually running the software might still require this. **daq-in-a-box instructions** should be updated, with some testing to confirm this behavior.

As a positive side effect, binary output directories for targets are no longer hijacked by some freaky config we had before. We have redirected the binaries as follows:
* executables in `bin`
* EFU modules in `bin/modules`
* unit test executables in `unit_tests`
* integration test executables in `integration_tests` (so far this is only for ADC)

If this is not to someone's liking, we can redirect them wherever else we want.
However, this may mean that **deployment scripts** and **daq-in-a-box instructions** have to be updated.

Jenkinsfile has been updated, artifact archiving factored out into a function. Tests are built in parallel, using custom target `unit_tests` but are run sequentially.