### PR TITLE
Add release information to artefact

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,9 +205,9 @@ def docker_archive(image_key) {
 
                         # Create file with build information
                         touch BUILD_INFO
-                        echo \"Repository: ${project}/${env.BRANCH_NAME}\" >> BUILD_INFO
-                        echo \"Commit: ${git_commit}\" >> BUILD_INFO
-                        echo \"Jenkins build: ${BUILD_NUMBER}\" >> BUILD_INFO
+                        echo 'Repository: ${project}/${env.BRANCH_NAME}' >> BUILD_INFO
+                        echo 'Commit: ${git_commit}' >> BUILD_INFO
+                        echo 'Jenkins build: ${BUILD_NUMBER}' >> BUILD_INFO
                     \""""
 
     sh "docker cp ${container_name(image_key)}:/home/jenkins/archive/event-formation-unit-centos7.tar.gz ."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ def docker_archive(image_key) {
     def custom_sh = images[image_key]['sh']
 
     git_commit = sh(
-        script: """docker exec ${container_name} ${custom_sh} -c \"
+        script: """docker exec ${container_name(image_key)} ${custom_sh} -c \"
                 cd ${project} && git rev-parse HEAD
             \"""",
         returnStdout: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,7 +199,7 @@ def docker_archive(image_key) {
                         # Create file with build information
                         touch BUILD_INFO
                         echo \"Repository: ${project}/${env.BRANCH_NAME}\" >> BUILD_INFO
-                        echo \"Commit: \\\$(git rev-parse HEAD)\" >> BUILD_INFO
+                        echo \"Commit: \\\\\\\$(git rev-parse HEAD)\" >> BUILD_INFO
                         echo \"Jenkins build: ${BUILD_NUMBER}\" >> BUILD_INFO
                     \""""
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,10 +195,17 @@ def docker_archive(image_key) {
                         cp -r ${project}/prototype2/multigrid/calib_data/* archive/event-formation-unit/data && \
                         cd archive && \
                         tar czvf event-formation-unit-centos7.tar.gz event-formation-unit
+
+                        # Create file with build information
+                        touch BUILD_INFO
+                        echo "Repository: ${project}/${env.BRANCH_NAME}" >> BUILD_INFO
+                        echo "Commit: \$(git rev-parse HEAD)" >> BUILD_INFO
+                        echo "Jenkins build: ${BUILD_NUMBER}" >> BUILD_INFO
                     \""""
 
     sh "docker cp ${container_name(image_key)}:/home/jenkins/archive/event-formation-unit-centos7.tar.gz ."
-    archiveArtifacts "event-formation-unit-centos7.tar.gz"
+    sh "docker cp ${container_name(image_key)}:/home/jenkins/archive/BUILD_INFO ."
+    archiveArtifacts "event-formation-unit-centos7.tar.gz,BUILD_INFO"
 }
 
 def get_pipeline(image_key)
@@ -208,7 +215,7 @@ def get_pipeline(image_key)
             node ("docker") {
                 try {
                     def container = get_container(image_key)
-                    
+
                     docker_clone(image_key)
                     if (image_key != clangformat_os) {
                       docker_dependencies(image_key)
@@ -219,7 +226,7 @@ def get_pipeline(image_key)
                     if (image_key == coverage_on) {
                         docker_tests_coverage(image_key)
                     } else if (image_key == clangformat_os) {
-                        
+
                     } else {
                       docker_tests(image_key)
                     }
@@ -227,7 +234,7 @@ def get_pipeline(image_key)
                     if (image_key == archive_what) {
                         docker_archive(image_key)
                     }
-                    
+
                     if (image_key == clangformat_os) {
                         docker_cppcheck(image_key)
                         step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: "cppcheck.txt"]]])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,6 +181,13 @@ def docker_tests_coverage(image_key) {
 def docker_archive(image_key) {
     def custom_sh = images[image_key]['sh']
 
+    git_commit = sh(
+        script: """docker exec ${container_name} ${custom_sh} -c \"
+                cd ${project} && git rev-parse HEAD
+            \"""",
+        returnStdout: true
+    ).trim()
+
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
                         mkdir -p archive/event-formation-unit && \
                         cp -r ${project}/build/bin archive/event-formation-unit && \
@@ -199,7 +206,7 @@ def docker_archive(image_key) {
                         # Create file with build information
                         touch BUILD_INFO
                         echo \"Repository: ${project}/${env.BRANCH_NAME}\" >> BUILD_INFO
-                        echo \"Commit: \\\\\\\$(git rev-parse HEAD)\" >> BUILD_INFO
+                        echo \"Commit: ${git_commit}\" >> BUILD_INFO
                         echo \"Jenkins build: ${BUILD_NUMBER}\" >> BUILD_INFO
                     \""""
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,9 +198,9 @@ def docker_archive(image_key) {
 
                         # Create file with build information
                         touch BUILD_INFO
-                        echo "Repository: ${project}/${env.BRANCH_NAME}" >> BUILD_INFO
-                        echo "Commit: \$(git rev-parse HEAD)" >> BUILD_INFO
-                        echo "Jenkins build: ${BUILD_NUMBER}" >> BUILD_INFO
+                        echo \"Repository: ${project}/${env.BRANCH_NAME}\" >> BUILD_INFO
+                        echo \"Commit: \\\$(git rev-parse HEAD)\" >> BUILD_INFO
+                        echo \"Jenkins build: ${BUILD_NUMBER}\" >> BUILD_INFO
                     \""""
 
     sh "docker cp ${container_name(image_key)}:/home/jenkins/archive/event-formation-unit-centos7.tar.gz ."


### PR DESCRIPTION
Add a BUILD_INFO artefact with project name, commit SHA and Jenkins build number. As we deploy the archive directly from Jenkins, this makes it easier to identify which version has been deployed and can be displayed in the integration test.