### PR TITLE
"Real" log message support in the EFU

### DIFF
--- a/Utilities.cmake
+++ b/Utilities.cmake
@@ -46,9 +46,9 @@ function(create_executable exec_name)
     ${${exec_name}_INC})
 
   target_link_libraries(${exec_name}
-    ${${exec_name}_LIB}
+    PUBLIC ${${exec_name}_LIB}
     ${EFU_COMMON_LIBS}
-    eventlib)
+    eventlib efu_common)
 
   if (GPERF)
     target_link_libraries(${exec_name} ${GPERFTOOLS_PROFILER})

--- a/Utilities.cmake
+++ b/Utilities.cmake
@@ -84,7 +84,7 @@ function(create_test_executable)
   target_link_libraries(${exec_name}
     ${${exec_name}_LIB}
     ${EFU_COMMON_LIBS}
-    ${GTEST_LIBRARIES})
+    ${GTEST_LIBRARIES} efu_common)
 
   if(${CMAKE_COMPILER_IS_GNUCXX})
     add_linker_flags(${exec_name} "-Wl,--no-as-needed")
@@ -120,5 +120,5 @@ function(create_integration_test_executable exec_name)
   target_link_libraries(${exec_name}
     ${${exec_name}_LIB}
     ${EFU_COMMON_LIBS}
-    eventlib)
+    eventlib efu_common)
 endfunction(create_integration_test_executable)

--- a/Utilities.cmake
+++ b/Utilities.cmake
@@ -7,7 +7,7 @@ function(create_module module_name)
     ${${module_name}_INC})
   set_target_properties(${module_name} PROPERTIES PREFIX "")
   set_target_properties(${module_name} PROPERTIES SUFFIX ".so")
-  target_link_libraries(${module_name}
+  target_link_libraries(${module_name} efu
     ${${module_name}_LIB}
     ${EFU_COMMON_LIBS}
     eventlib)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -11,6 +11,7 @@ trompeloeil/v31@ess-dmsc/stable
 asio/1.11.0@bincrafters/stable
 readerwriterqueue/07e22ec@ess-dmsc/stable
 cmake_installer/3.10.0@conan/stable
+fmt/5.1.0@bincrafters/stable
 
 [generators]
 cmake

--- a/dataformats/multigrid/CMakeLists.txt
+++ b/dataformats/multigrid/CMakeLists.txt
@@ -17,6 +17,8 @@ add_executable(batchreader
   ../../prototype2/multigrid/mgcncs/DataParser.cpp
   )
 
+target_link_libraries(batchreader PRIVATE efu_common)
+
 add_executable(cncsread src/cncsread.cpp)
 
 add_executable(genpixids
@@ -25,6 +27,7 @@ add_executable(genpixids
   ../../prototype2/multigrid/mgcncs/ChanConv.cpp
   ../../prototype2/multigrid/mgcncs/CalibrationFile.cpp
   )
+target_link_libraries(genpixids PRIVATE efu_common)
 
 #
 # Install Files

--- a/dataformats/multigrid/inc/RunSpecParseTest.cpp
+++ b/dataformats/multigrid/inc/RunSpecParseTest.cpp
@@ -43,7 +43,7 @@ TEST_F(RunSpecParseTest, InvalidJson) {
   RunSpecParse runspec(filename);
 
   // DeathTest
-  ASSERT_EXIT(runspec.getruns("test", "basedir", "outputdir", 1, 200), ::testing::ExitedWithCode(1), "");
+  ASSERT_THROW(runspec.getruns("test", "basedir", "outputdir", 1, 200), std::runtime_error);
 }
 
 int main(int argc, char **argv) {

--- a/dataformats/multigrid/src/RunSpecParse.cpp
+++ b/dataformats/multigrid/src/RunSpecParse.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iomanip>
 #include <string>
+#include <stdexcept>
 
 RunSpecParse::RunSpecParse(std::string filename) : jsonfile(filename) {}
 
@@ -26,7 +27,7 @@ std::vector<RunSpec *> &RunSpecParse::getruns(std::string runspec,
 
   if (!reader.parse(str, root, 0)) {
     printf("error: file \"%s\" is not valid json\n", jsonfile.c_str());
-    exit(1);
+    throw std::runtime_error("Parsed file was not valid JSON.");
   }
 
   const Json::Value plugins = root[runspec];

--- a/libs/source/Socket.cpp
+++ b/libs/source/Socket.cpp
@@ -42,8 +42,8 @@ void Socket::getBufferSizes(int & sendBuffer, int & receiveBuffer) {
 }
 
 void Socket::printBufferSizes(void) {
-  LOG(Sev::Info, "Socket receive buffer size: %d", getSockOpt(SO_RCVBUF));
-  LOG(Sev::Info, "Socket send buffer size: %d", getSockOpt(SO_SNDBUF));
+  LOG(Sev::Info, "Socket receive buffer size: {}", getSockOpt(SO_RCVBUF));
+  LOG(Sev::Info, "Socket send buffer size: {}", getSockOpt(SO_SNDBUF));
 }
 
 int Socket::setRecvTimeout(int seconds, int usecs) {
@@ -156,7 +156,7 @@ int TCPTransmitter::senddata(char *buffer, int len) {
   }
   int ret = send(socketFileDescriptor, buffer, len, 0);
   if (ret <= 0) {
-    LOG(Sev::Warning, "TCPClient::send() returns %d", ret);
+    LOG(Sev::Warning, "TCPClient::send() returns {}", ret);
   }
   return ret;
 }

--- a/libs/source/Socket.cpp
+++ b/libs/source/Socket.cpp
@@ -4,14 +4,14 @@
 #include <cstring>
 #include <iostream>
 #include <libs/include/Socket.h>
-#include <prototype2/common/Trace.h>
+#include <prototype2/common/Log.h>
 
 Socket::Socket(Socket::type stype) {
   auto type = (stype == Socket::type::UDP) ? SOCK_DGRAM : SOCK_STREAM;
   auto proto = (stype == Socket::type::UDP) ? IPPROTO_UDP : IPPROTO_TCP;
 
   if ((socketFileDescriptor = socket(AF_INET, type, proto)) == -1) {
-    XTRACE(INIT, ALW, "socket() failed");
+    LOG(Sev::Error, "socket() failed");
     exit(1);
   }
 }
@@ -42,8 +42,8 @@ void Socket::getBufferSizes(int & sendBuffer, int & receiveBuffer) {
 }
 
 void Socket::printBufferSizes(void) {
-  XTRACE(IPC, ALW, "Socket receive buffer size: %d", getSockOpt(SO_RCVBUF));
-  XTRACE(IPC, ALW, "Socket send buffer size: %d", getSockOpt(SO_SNDBUF));
+  LOG(Sev::Info, "Socket receive buffer size: %d", getSockOpt(SO_RCVBUF));
+  LOG(Sev::Info, "Socket send buffer size: %d", getSockOpt(SO_SNDBUF));
 }
 
 int Socket::setRecvTimeout(int seconds, int usecs) {
@@ -140,7 +140,7 @@ TCPTransmitter::TCPTransmitter(const char *ipaddr, int port) {
 
   ret = connect(socketFileDescriptor, (struct sockaddr *)&remoteSockAddr, sizeof(remoteSockAddr));
   if (ret < 0) {
-    XTRACE(IPC, ALW, "connect() to %s:%d failed", ipaddr, port);
+    LOG(Sev::Error, "connect() to {}:{} failed", ipaddr, port);
     socketFileDescriptor = -1;
   }
 }
@@ -151,12 +151,12 @@ int TCPTransmitter::senddata(char *buffer, int len) {
   }
 
   if (len <= 0) {
-    XTRACE(IPC, WAR, "TCPClient::senddata() no data specified");
+    LOG(Sev::Warning, "TCPClient::senddata() no data specified");
     return 0;
   }
   int ret = send(socketFileDescriptor, buffer, len, 0);
   if (ret <= 0) {
-    XTRACE(IPC, WAR, "TCPClient::send() returns %d", ret);
+    LOG(Sev::Warning, "TCPClient::send() returns %d", ret);
   }
   return ret;
 }

--- a/libs/source/Socket.cpp
+++ b/libs/source/Socket.cpp
@@ -11,7 +11,7 @@ Socket::Socket(Socket::type stype) {
   auto proto = (stype == Socket::type::UDP) ? IPPROTO_UDP : IPPROTO_TCP;
 
   if ((socketFileDescriptor = socket(AF_INET, type, proto)) == -1) {
-    XTRACE(INIT, ALW, "socket() failed\n");
+    XTRACE(INIT, ALW, "socket() failed");
     exit(1);
   }
 }
@@ -42,8 +42,8 @@ void Socket::getBufferSizes(int & sendBuffer, int & receiveBuffer) {
 }
 
 void Socket::printBufferSizes(void) {
-  XTRACE(IPC, ALW, "Socket receive buffer size: %d\n", getSockOpt(SO_RCVBUF));
-  XTRACE(IPC, ALW, "Socket send buffer size: %d\n", getSockOpt(SO_SNDBUF));
+  XTRACE(IPC, ALW, "Socket receive buffer size: %d", getSockOpt(SO_RCVBUF));
+  XTRACE(IPC, ALW, "Socket send buffer size: %d", getSockOpt(SO_SNDBUF));
 }
 
 int Socket::setRecvTimeout(int seconds, int usecs) {
@@ -140,7 +140,7 @@ TCPTransmitter::TCPTransmitter(const char *ipaddr, int port) {
 
   ret = connect(socketFileDescriptor, (struct sockaddr *)&remoteSockAddr, sizeof(remoteSockAddr));
   if (ret < 0) {
-    XTRACE(IPC, ALW, "connect() to %s:%d failed\n", ipaddr, port);
+    XTRACE(IPC, ALW, "connect() to %s:%d failed", ipaddr, port);
     socketFileDescriptor = -1;
   }
 }
@@ -151,12 +151,12 @@ int TCPTransmitter::senddata(char *buffer, int len) {
   }
 
   if (len <= 0) {
-    XTRACE(IPC, WAR, "TCPClient::senddata() no data specified\n");
+    XTRACE(IPC, WAR, "TCPClient::senddata() no data specified");
     return 0;
   }
   int ret = send(socketFileDescriptor, buffer, len, 0);
   if (ret <= 0) {
-    XTRACE(IPC, WAR, "TCPClient::send() returns %d\n", ret);
+    XTRACE(IPC, WAR, "TCPClient::send() returns %d", ret);
   }
   return ret;
 }

--- a/prototype2/adc_readout/AdcReadoutBase.cpp
+++ b/prototype2/adc_readout/AdcReadoutBase.cpp
@@ -119,12 +119,10 @@ void AdcReadoutBase::processingThread(Queue &DataModuleQueue) {
   std::vector<std::unique_ptr<AdcDataProcessor>> Processors;
 
   if (ReadoutSettings.PeakDetection) {
-    LOG(Sev::Info, "AdcReadout: Peak detection enabled.");
     Processors.push_back(
         std::unique_ptr<AdcDataProcessor>(new PeakFinder(getProducer())));
   }
   if (ReadoutSettings.SerializeSamples) {
-    LOG(Sev::Info, "AdcReadout: Sample serialisation enabled.");
     std::unique_ptr<AdcDataProcessor> Processor(
         new SampleProcessing(getProducer(), ReadoutSettings.Name));
     dynamic_cast<SampleProcessing *>(Processor.get())

--- a/prototype2/adc_readout/AdcReadoutBase.cpp
+++ b/prototype2/adc_readout/AdcReadoutBase.cpp
@@ -10,6 +10,7 @@
 #include "PeakFinder.h"
 #include "SampleProcessing.h"
 #include "libs/include/Socket.h"
+#include <common/Log.h>
 
 AdcReadoutBase::AdcReadoutBase(BaseSettings const &Settings,
                                AdcSettings &ReadoutSettings)
@@ -118,10 +119,12 @@ void AdcReadoutBase::processingThread(Queue &DataModuleQueue) {
   std::vector<std::unique_ptr<AdcDataProcessor>> Processors;
 
   if (ReadoutSettings.PeakDetection) {
+    LOG(Sev::Info, "AdcReadout: Peak detection enabled.");
     Processors.push_back(
         std::unique_ptr<AdcDataProcessor>(new PeakFinder(getProducer())));
   }
   if (ReadoutSettings.SerializeSamples) {
+    LOG(Sev::Info, "AdcReadout: Sample serialisation enabled.");
     std::unique_ptr<AdcDataProcessor> Processor(
         new SampleProcessing(getProducer(), ReadoutSettings.Name));
     dynamic_cast<SampleProcessing *>(Processor.get())

--- a/prototype2/common/CMakeLists.txt
+++ b/prototype2/common/CMakeLists.txt
@@ -8,7 +8,6 @@ set(efu_common_SRC
   Producer.cpp
   DataSave.cpp
   DetectorModuleRegister.cpp
-  Log.cpp
   )
 set(efu_common_INC
   ../../libs/include/gccintel.h

--- a/prototype2/common/CMakeLists.txt
+++ b/prototype2/common/CMakeLists.txt
@@ -7,6 +7,7 @@ set(efu_common_SRC
   Producer.cpp
   DataSave.cpp
   DetectorModuleRegister.cpp
+  Log.cpp
   )
 set(efu_common_INC
   ../../libs/include/gccintel.h
@@ -17,6 +18,7 @@ set(efu_common_INC
   NewStats.h
   Producer.h
   Trace.h
+  Log.h
   DataSave.h
   )
 

--- a/prototype2/common/CMakeLists.txt
+++ b/prototype2/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 #=============================================================================
 # Common functionality for all detector plugins
 #=============================================================================
+
 set(efu_common_SRC
   FBSerializer.cpp
   NewStats.cpp
@@ -23,6 +24,7 @@ set(efu_common_INC
   )
 
 find_package(CLI11 REQUIRED)
+find_package(fmt REQUIRED)
 
 add_library(efu_common STATIC
   ${efu_common_SRC}
@@ -36,8 +38,7 @@ endif()
 
 enable_coverage(efu_common)
 
-target_link_libraries(efu_common
-    ${EFU_COMMON_LIBS})
+target_link_libraries(efu_common PUBLIC ${EFU_COMMON_LIBS} fmt::fmt)
 
 set(EFU_COMMON_LIBS ${EFU_COMMON_LIBS} efu_common PARENT_SCOPE)
 

--- a/prototype2/common/CMakeLists.txt
+++ b/prototype2/common/CMakeLists.txt
@@ -40,8 +40,6 @@ enable_coverage(efu_common)
 
 target_link_libraries(efu_common PUBLIC ${EFU_COMMON_LIBS} fmt::fmt)
 
-set(EFU_COMMON_LIBS ${EFU_COMMON_LIBS} efu_common PARENT_SCOPE)
-
 
 #=============================================================================
 # Tests

--- a/prototype2/common/DataSave.cpp
+++ b/prototype2/common/DataSave.cpp
@@ -68,18 +68,18 @@ int DataSave::tofile(const char *fmt, ...) {
   va_end(args);
 
   if (ret < 0) {
-    XTRACE(PROCESS, ERR, "vsnprintf failed\n");
+    XTRACE(PROCESS, ERR, "vsnprintf failed");
     return ret;
   }
 
   if (ret > maxwritelen) {
-    XTRACE(PROCESS, WAR, "datasave has been truncated\n");
+    XTRACE(PROCESS, WAR, "datasave has been truncated");
     ret = maxwritelen;
   }
 
   bufferlen += ret;
   if (bufferlen >= BUFFERSIZE) {
-    XTRACE(PROCESS, DEB, "Writing chunk of size %d\n", bufferlen);
+    XTRACE(PROCESS, DEB, "Writing chunk of size %d", bufferlen);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
     write(fd, buffer, bufferlen);
@@ -91,9 +91,9 @@ int DataSave::tofile(const char *fmt, ...) {
 }
 
 DataSave::~DataSave() {
-  XTRACE(PROCESS, DEB, "~DataSave bufferlen %d\n", bufferlen);
+  XTRACE(PROCESS, DEB, "~DataSave bufferlen %d", bufferlen);
   if (bufferlen > 0) {
-    XTRACE(PROCESS, INF, "Flushing DataSave buffer\n");
+    XTRACE(PROCESS, INF, "Flushing DataSave buffer");
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
     write(fd, buffer, bufferlen);

--- a/prototype2/common/DataSave.cpp
+++ b/prototype2/common/DataSave.cpp
@@ -2,7 +2,7 @@
 
 #include <cassert>
 #include <common/DataSave.h>
-#include <prototype2/common/Trace.h>
+#include <prototype2/common/Log.h>
 
 //#undef TRC_LEVEL
 //#define TRC_LEVEL TRC_L_DEB
@@ -68,18 +68,18 @@ int DataSave::tofile(const char *fmt, ...) {
   va_end(args);
 
   if (ret < 0) {
-    XTRACE(PROCESS, ERR, "vsnprintf failed");
+    LOG(Sev::Error, "vsnprintf failed");
     return ret;
   }
 
   if (ret > maxwritelen) {
-    XTRACE(PROCESS, WAR, "datasave has been truncated");
+    LOG(Sev::Warning, "datasave has been truncated");
     ret = maxwritelen;
   }
 
   bufferlen += ret;
   if (bufferlen >= BUFFERSIZE) {
-    XTRACE(PROCESS, DEB, "Writing chunk of size %d", bufferlen);
+    LOG(Sev::Debug, "Writing chunk of size {}", bufferlen);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
     write(fd, buffer, bufferlen);
@@ -91,9 +91,9 @@ int DataSave::tofile(const char *fmt, ...) {
 }
 
 DataSave::~DataSave() {
-  XTRACE(PROCESS, DEB, "~DataSave bufferlen %d", bufferlen);
+  LOG(Sev::Debug, "~DataSave bufferlen {}", bufferlen);
   if (bufferlen > 0) {
-    XTRACE(PROCESS, INF, "Flushing DataSave buffer");
+    LOG(Sev::Info, "Flushing DataSave buffer");
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
     write(fd, buffer, bufferlen);

--- a/prototype2/common/Detector.h
+++ b/prototype2/common/Detector.h
@@ -12,7 +12,6 @@
 #include <CLI11.hpp>
 #include <atomic>
 #include <common/NewStats.h>
-#include <common/Trace.h>
 #include <functional>
 #include <map>
 #include <memory>

--- a/prototype2/common/EFUArgs.cpp
+++ b/prototype2/common/EFUArgs.cpp
@@ -130,24 +130,24 @@ bool EFUArgs::parseAffinityStrings(
 
 void EFUArgs::printSettings() {
   // clang-format off
-  XTRACE(INIT, ALW, "Starting event processing pipeline2 with main properties:\n");
-  XTRACE(INIT, ALW, "  Detector:                 %s\n",    DetectorName.c_str());
-  XTRACE(INIT, ALW, "  Rx UDP Socket:            %s:%d\n",
+  XTRACE(INIT, ALW, "Starting event processing pipeline2 with main properties:");
+  XTRACE(INIT, ALW, "  Detector:                 %s",    DetectorName.c_str());
+  XTRACE(INIT, ALW, "  Rx UDP Socket:            %s:%d",
          EFUSettings.DetectorAddress.c_str(), EFUSettings.DetectorPort);
-  XTRACE(INIT, ALW, "  Minimum required MTU      %d\n", EFUSettings.MinimumMTU);
-  XTRACE(INIT, ALW, "  Kafka broker:             %s\n", EFUSettings.KafkaBroker.c_str());
-  XTRACE(INIT, ALW, "  Log IP:                   %s\n", GraylogConfig.address.c_str());
-  XTRACE(INIT, ALW, "  Graphite TCP socket:      %s:%d\n",
+  XTRACE(INIT, ALW, "  Minimum required MTU      %d", EFUSettings.MinimumMTU);
+  XTRACE(INIT, ALW, "  Kafka broker:             %s", EFUSettings.KafkaBroker.c_str());
+  XTRACE(INIT, ALW, "  Log IP:                   %s", GraylogConfig.address.c_str());
+  XTRACE(INIT, ALW, "  Graphite TCP socket:      %s:%d",
         EFUSettings.GraphiteAddress.c_str(), EFUSettings.GraphitePort);
-  XTRACE(INIT, ALW, "  CLI TCP Socket:           localhost:%d\n", EFUSettings.CommandServerPort);
+  XTRACE(INIT, ALW, "  CLI TCP Socket:           localhost:%d", EFUSettings.CommandServerPort);
 
   if (EFUSettings.StopAfterSec == 0xffffffffU) {
-    XTRACE(INIT, ALW, "  Stopafter:                never\n");
+    XTRACE(INIT, ALW, "  Stopafter:                never");
   } else {
-    XTRACE(INIT, ALW, "  Stopafter:                %us\n", EFUSettings.StopAfterSec);
+    XTRACE(INIT, ALW, "  Stopafter:                %us", EFUSettings.StopAfterSec);
   }
 
-  XTRACE(INIT, ALW, "<<< NOT ALL CONFIGURABLE SETTINGS MAY BE DISPLAYED >>>\n");
+  XTRACE(INIT, ALW, "<<< NOT ALL CONFIGURABLE SETTINGS MAY BE DISPLAYED >>>");
   // clang-format on
 }
 

--- a/prototype2/common/EFUArgs.cpp
+++ b/prototype2/common/EFUArgs.cpp
@@ -8,10 +8,9 @@
 
 #include <common/DetectorModuleRegister.h>
 #include <common/EFUArgs.h>
-#include <common/Trace.h>
+#include <common/Log.h>
 #include <cstdio>
 #include <fstream>
-#include <iostream>
 #include <regex>
 #include <string>
 
@@ -37,6 +36,14 @@ EFUArgs::EFUArgs() {
                     return parseAffinityStrings(Input);
                   }, "Thread to core affinity. Ex: \"-c input_t:4\"")
       ->group("EFU Options");
+  
+  CLIParser.add_option("-l,--log_level", [this](std::vector<std::string> Input) {
+    return parseLogLevel(Input);
+  }, "Set log message level. Set to 1 - 7 or one of \n                              `Critical`, `Error`, `Warning`, `Notice`, `Info`,\n                              or `Debug`. Ex: \"-l Notice\"")
+  ->group("EFU Options")->set_default_val("Info");
+  
+  CLIParser.add_option("--log_file", LogFileName, "Write log messages to file.")
+  ->group("EFU Options");
 
   CLIParser.add_option("-u,--min_mtu", EFUSettings.MinimumMTU, "Minimum value of MTU for all active interfaces")
       ->group("EFU Options")->set_default_val("9000");
@@ -128,26 +135,49 @@ bool EFUArgs::parseAffinityStrings(
   return true;
 }
 
+bool EFUArgs::parseLogLevel(std::vector<std::string> LogLevelString) {
+  std::map<std::string, int> LevelMap{{"Critical", 2}, {"Error", 3}, {"Warning", 4}, {"Notice", 5}, {"Info", 6}, {"Debug", 7}};
+  if (LogLevelString.size() != 1) {
+    return false;
+  }
+  try {
+    LogMessageLevel = LevelMap.at(LogLevelString.at(0));
+    return true;
+  } catch (std::out_of_range &e) {
+    //Do nothing
+  }
+  try {
+    int TempLogMessageLevel = std::stoi(LogLevelString.at(0));
+    if (TempLogMessageLevel < 1 or TempLogMessageLevel > 7) {
+      return false;
+    }
+    LogMessageLevel = TempLogMessageLevel;
+  } catch (std::invalid_argument &e) {
+    return false;
+  }
+  return true;
+}
+
 void EFUArgs::printSettings() {
   // clang-format off
-  XTRACE(INIT, ALW, "Starting event processing pipeline2 with main properties:");
-  XTRACE(INIT, ALW, "  Detector:                 %s",    DetectorName.c_str());
-  XTRACE(INIT, ALW, "  Rx UDP Socket:            %s:%d",
-         EFUSettings.DetectorAddress.c_str(), EFUSettings.DetectorPort);
-  XTRACE(INIT, ALW, "  Minimum required MTU      %d", EFUSettings.MinimumMTU);
-  XTRACE(INIT, ALW, "  Kafka broker:             %s", EFUSettings.KafkaBroker.c_str());
-  XTRACE(INIT, ALW, "  Log IP:                   %s", GraylogConfig.address.c_str());
-  XTRACE(INIT, ALW, "  Graphite TCP socket:      %s:%d",
-        EFUSettings.GraphiteAddress.c_str(), EFUSettings.GraphitePort);
-  XTRACE(INIT, ALW, "  CLI TCP Socket:           localhost:%d", EFUSettings.CommandServerPort);
+  LOG(Sev::Info, "Starting event processing pipeline2 with main properties:");
+  LOG(Sev::Info, "  Detector:                 {}",    DetectorName);
+  LOG(Sev::Info, "  Rx UDP Socket:            {}:{}",
+         EFUSettings.DetectorAddress, EFUSettings.DetectorPort);
+  LOG(Sev::Info, "  Minimum required MTU      {}", EFUSettings.MinimumMTU);
+  LOG(Sev::Info, "  Kafka broker:             {}", EFUSettings.KafkaBroker);
+  LOG(Sev::Info, "  Log IP:                   {}", GraylogConfig.address);
+  LOG(Sev::Info, "  Graphite TCP socket:      {}:{}",
+        EFUSettings.GraphiteAddress, EFUSettings.GraphitePort);
+  LOG(Sev::Info, "  CLI TCP Socket:           localhost:{}", EFUSettings.CommandServerPort);
 
   if (EFUSettings.StopAfterSec == 0xffffffffU) {
-    XTRACE(INIT, ALW, "  Stopafter:                never");
+    LOG(Sev::Info, "  Stopafter:                never");
   } else {
-    XTRACE(INIT, ALW, "  Stopafter:                %us", EFUSettings.StopAfterSec);
+    LOG(Sev::Info, "  Stopafter:                {}s", EFUSettings.StopAfterSec);
   }
 
-  XTRACE(INIT, ALW, "<<< NOT ALL CONFIGURABLE SETTINGS MAY BE DISPLAYED >>>");
+  LOG(Sev::Info, "<<< NOT ALL CONFIGURABLE SETTINGS MAY BE DISPLAYED >>>");
   // clang-format on
 }
 
@@ -184,12 +214,12 @@ EFUArgs::Status EFUArgs::parseSecondPass(const int argc, char *argv[]) {
   if (*WriteConfigOption) {
     std::ofstream ConfigFile(ConfigFileName, std::ios::binary);
     if (not ConfigFile.is_open()) {
-      std::cout << "Failed to open config file for writing." << std::endl;
+      LOG(Sev::Error, "Failed to open config file for writing.");
       return Status::EXIT;
     }
     ConfigFile << CLIParser.config_to_str(true, "", true);
     ConfigFile.close();
-    std::cout << "Config file created, now exiting." << std::endl;
+    LOG(Sev::Info, "Config file created, now exiting.");
     return Status::EXIT;
   }
   return Status::CONTINUE;

--- a/prototype2/common/EFUArgs.cpp
+++ b/prototype2/common/EFUArgs.cpp
@@ -144,7 +144,7 @@ bool EFUArgs::parseLogLevel(std::vector<std::string> LogLevelString) {
     LogMessageLevel = LevelMap.at(LogLevelString.at(0));
     return true;
   } catch (std::out_of_range &e) {
-    //Do nothing
+    // Do nothing
   }
   try {
     int TempLogMessageLevel = std::stoi(LogLevelString.at(0));

--- a/prototype2/common/EFUArgs.h
+++ b/prototype2/common/EFUArgs.h
@@ -42,6 +42,9 @@ public:
   std::vector<ThreadCoreAffinitySetting> getThreadCoreAffinity() {
     return ThreadAffinity;
   };
+  
+  int getLogLevel() {return LogMessageLevel;};
+  std::string getLogFileName() {return LogFileName;};
 
   BaseSettings getBaseSettings() { return EFUSettings; };
 
@@ -51,8 +54,10 @@ public:
 
 private:
   bool parseAffinityStrings(std::vector<std::string> ThreadAffinityStrings);
-
+  bool parseLogLevel(std::vector<std::string> LogLevelString);
+  int LogMessageLevel{6};
   std::string DetectorName;
+  std::string LogFileName;
 
   std::vector<ThreadCoreAffinitySetting> ThreadAffinity;
   CLI::Option *DetectorOption;

--- a/prototype2/common/FBSerializer.cpp
+++ b/prototype2/common/FBSerializer.cpp
@@ -72,11 +72,11 @@ int FBSerializer::produce() {
     // }
     // printf("\n");
 
-    XTRACE(OUTPUT, DEB, "produce %zu events \n", events);
+    XTRACE(OUTPUT, DEB, "produce %zu events ", events);
     char *txbuffer;
     txlen = serialize((uint64_t)0x01, seqno++, events, &txbuffer);
     assert(txlen > 0);
-    XTRACE(OUTPUT, DEB, "Flatbuffer tx length %d\n", txlen);
+    XTRACE(OUTPUT, DEB, "Flatbuffer tx length %d", txlen);
     producer.produce(txbuffer, txlen);
 
 #if 0
@@ -90,7 +90,7 @@ int FBSerializer::produce() {
 }
 
 int FBSerializer::addevent(uint32_t time, uint32_t pixel) {
-  XTRACE(OUTPUT, DEB, "Add event: %d %u\n", time, pixel);
+  XTRACE(OUTPUT, DEB, "Add event: %d %u", time, pixel);
   ((uint32_t *)timeptr)[events] = time;
   ((uint32_t *)pixelptr)[events] = pixel;
   events++;

--- a/prototype2/common/Log.cpp
+++ b/prototype2/common/Log.cpp
@@ -1,0 +1,2 @@
+
+#include "Log.h"

--- a/prototype2/common/Log.cpp
+++ b/prototype2/common/Log.cpp
@@ -1,2 +1,0 @@
-
-#include "Log.h"

--- a/prototype2/common/Log.h
+++ b/prototype2/common/Log.h
@@ -3,11 +3,10 @@
 #pragma once
 
 #include <fmt/format.h>
-#include <iostream>
-#include <string>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #include <graylog_logger/GraylogInterface.hpp>
+#include <graylog_logger/FileInterface.hpp>
 #include <graylog_logger/Log.hpp>
 #pragma GCC diagnostic pop
 

--- a/prototype2/common/Log.h
+++ b/prototype2/common/Log.h
@@ -3,10 +3,13 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <cstdint>
+#include <libgen.h>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #include <graylog_logger/GraylogInterface.hpp>
 #include <graylog_logger/FileInterface.hpp>
+#include <graylog_logger/ConsoleInterface.hpp>
 #include <graylog_logger/Log.hpp>
 #pragma GCC diagnostic pop
 
@@ -22,5 +25,9 @@ enum class Sev : int {
   Info = 6,
   Debug = 7,
   };
-
-#define LOG(Severity, Format, ...) Log::Msg(int(Severity), fmt::format(Format, ##__VA_ARGS__))
+  
+  inline int SevToInt(Sev Level) { // Force the use of the correct type
+    return static_cast<int>(Level);
+  }
+  
+#define LOG(Severity, Format, ...) Log::Msg(SevToInt(Severity), fmt::format(Format, ##__VA_ARGS__), {{"file", std::string(__FILE__)}, {"line", std::int64_t(__LINE__)}})

--- a/prototype2/common/Log.h
+++ b/prototype2/common/Log.h
@@ -1,19 +1,27 @@
+/** Copyright (C) 2018 European Spallation Source ERIC */
 
-//#ifdef GRAYLOG
-//#pragma GCC diagnostic push
-//#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-//#include <graylog_logger/GraylogInterface.hpp>
-//#include <graylog_logger/Log.hpp>
-//#pragma GCC diagnostic pop
-//#define GLOG_DEB(x) Log::Msg(Severity::Debug, x)
-//#define GLOG_INF(x) Log::Msg(Severity::Informational, x)
-//#define GLOG_WAR(x) Log::Msg(Severity::Warning, x)
-//#define GLOG_ERR(x) Log::Msg(Severity::Error, x)
-//#define GLOG_CRI(x) Log::Msg(Severity::Critical, x)
-//#else
-//#define GLOG_DEB(x)
-//#define GLOG_INF(x)
-//#define GLOG_WAR(x)
-//#define GLOG_ERR(x)
-//#define GLOG_CRI(x)
-//#endif
+#pragma once
+
+#include <fmt/format.h>
+#include <iostream>
+#include <string>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#include <graylog_logger/GraylogInterface.hpp>
+#include <graylog_logger/Log.hpp>
+#pragma GCC diagnostic pop
+
+#pragma GCC system_header
+
+enum class Sev : int {
+  Emergency = 0,
+  Alert = 1,
+  Critical = 2,
+  Error = 3,
+  Warning = 4,
+  Notice = 5,
+  Info = 6,
+  Debug = 7,
+  };
+
+#define LOG(Severity, Format, ...) Log::Msg(int(Severity), fmt::format(Format, ##__VA_ARGS__))

--- a/prototype2/common/Log.h
+++ b/prototype2/common/Log.h
@@ -1,0 +1,19 @@
+
+//#ifdef GRAYLOG
+//#pragma GCC diagnostic push
+//#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+//#include <graylog_logger/GraylogInterface.hpp>
+//#include <graylog_logger/Log.hpp>
+//#pragma GCC diagnostic pop
+//#define GLOG_DEB(x) Log::Msg(Severity::Debug, x)
+//#define GLOG_INF(x) Log::Msg(Severity::Informational, x)
+//#define GLOG_WAR(x) Log::Msg(Severity::Warning, x)
+//#define GLOG_ERR(x) Log::Msg(Severity::Error, x)
+//#define GLOG_CRI(x) Log::Msg(Severity::Critical, x)
+//#else
+//#define GLOG_DEB(x)
+//#define GLOG_INF(x)
+//#define GLOG_WAR(x)
+//#define GLOG_ERR(x)
+//#define GLOG_CRI(x)
+//#endif

--- a/prototype2/common/Producer.cpp
+++ b/prototype2/common/Producer.cpp
@@ -2,7 +2,7 @@
 
 #include <cassert>
 #include <common/Producer.h>
-#include <iostream>
+#include <common/Log.h>
 #include <libs/include/gccintel.h>
 
 Producer::Producer(std::string broker, std::string topicstr) : ProducerBase() {
@@ -11,12 +11,12 @@ Producer::Producer(std::string broker, std::string topicstr) : ProducerBase() {
   tconf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);
 
   if (conf == nullptr) {
-    std::cerr << "Unable to create CONF_GLOBAL object" << std::endl;
+    LOG(Sev::Error, "Unable to create CONF_GLOBAL object");
     return;
   }
 
   if (tconf == nullptr) {
-    std::cerr << "Unable to create CONF_TOPIC object" << std::endl;
+    LOG(Sev::Error, "Unable to create CONF_TOPIC object");
     return;
   }
 
@@ -33,14 +33,14 @@ Producer::Producer(std::string broker, std::string topicstr) : ProducerBase() {
 
   producer = RdKafka::Producer::create(conf, errstr);
   if (!producer) {
-    std::cerr << "Failed to create producer: " << errstr << std::endl;
+    LOG(Sev::Error, "Failed to create producer: {}", errstr);
     /** \todo add logging to Greylog */
     return;
   }
 
   topic = RdKafka::Topic::create(producer, topicstr, tconf, errstr);
   if (!topic) {
-    std::cerr << "Failed to create topic: " << errstr << std::endl;
+    LOG(Sev::Error, "Failed to create topic: {}", errstr);
     /** \todo add logging to Greylog */
     return;
   }
@@ -62,8 +62,7 @@ int Producer::produce(char *buffer, int length) {
       topic, -1, RdKafka::Producer::RK_MSG_COPY /* Copy payload */, buffer,
       length, NULL, NULL);
   if (resp != RdKafka::ERR_NO_ERROR) {
-    // std::cerr << "% Produce failed: " << RdKafka::err2str(resp) << std::endl;
-    printf("Produce failed: %s\n", RdKafka::err2str(resp).c_str());
+    LOG(Sev::Error, "Produce failed: {}", RdKafka::err2str(resp));
     return resp;
   }
   producer->poll(0);

--- a/prototype2/common/Trace.h
+++ b/prototype2/common/Trace.h
@@ -14,26 +14,6 @@
 #include <libgen.h>
 #include <stdarg.h>
 
-#ifdef GRAYLOG
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#include <graylog_logger/GraylogInterface.hpp>
-#include <graylog_logger/Log.hpp>
-#pragma GCC diagnostic pop
-#define GLOG_DEB(x) Log::Msg(Severity::Debug, x)
-#define GLOG_INF(x) Log::Msg(Severity::Informational, x)
-#define GLOG_WAR(x) Log::Msg(Severity::Warning, x)
-#define GLOG_ERR(x) Log::Msg(Severity::Error, x)
-#define GLOG_CRI(x) Log::Msg(Severity::Critical, x)
-#else
-#define GLOG_DEB(x)
-#define GLOG_INF(x)
-#define GLOG_WAR(x)
-#define GLOG_ERR(x)
-#define GLOG_CRI(x)
-#endif
-
-
 /** Add trace groups below - must be powers of two */
 // clang-format off
 const unsigned int TRC_G_INPUT   = 0x00000001U;

--- a/prototype2/common/Trace.h
+++ b/prototype2/common/Trace.h
@@ -7,8 +7,13 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#pragma once
+
 #include <cstdio>
+#include <cstdlib>
 #include <libgen.h>
+#include <stdarg.h>
+
 #ifdef GRAYLOG
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
@@ -28,59 +33,87 @@
 #define GLOG_CRI(x)
 #endif
 
-/// Add trace groups below - must be powers of two
+
+/** Add trace groups below - must be powers of two */
 // clang-format off
-#define TRC_G_INPUT   0x00000001U
-#define TRC_G_OUTPUT  0x00000002U
-#define TRC_G_PROCESS 0x00000004U
-#define TRC_G_MAIN    0x00000008U
-#define TRC_G_INIT    0x00000010U
-#define TRC_G_IPC     0x00000020U
-#define TRC_G_CMD     0x00000040U
-#define TRC_G_DATA    0x00000080U
+const unsigned int TRC_G_INPUT   = 0x00000001U;
+const unsigned int TRC_G_OUTPUT  = 0x00000002U;
+const unsigned int TRC_G_PROCESS = 0x00000004U;
+const unsigned int TRC_G_MAIN    = 0x00000008U;
+const unsigned int TRC_G_INIT    = 0x00000010U;
+const unsigned int TRC_G_IPC     = 0x00000020U;
+const unsigned int TRC_G_CMD     = 0x00000040U;
+const unsigned int TRC_G_DATA    = 0x00000080U;
 
-/// Add trace masks below, bitwise or of grouops
-#define TRC_M_ALL                                                              \
-  (TRC_G_INPUT | TRC_G_OUTPUT | TRC_G_PROCESS | TRC_G_MAIN | TRC_G_INIT |      \
-   TRC_G_IPC   | TRC_G_CMD | TRC_G_DATA)
+/** Add trace masks below, bitwise or of grouops */
+constexpr unsigned int TRC_M_ALL = (TRC_G_INPUT | TRC_G_OUTPUT | TRC_G_PROCESS | TRC_G_MAIN | TRC_G_INIT | TRC_G_IPC   | TRC_G_CMD | TRC_G_DATA);
 
-/// Do not edit below
-#define TRC_M_NONE 0
+/** Do not edit below */
+const unsigned int TRC_M_NONE = 0;
 
-#define TRC_L_ALW 12
-#define TRC_L_CRI 10
-#define TRC_L_ERR 8
-#define TRC_L_WAR 6
-#define TRC_L_INF 4
-#define TRC_L_DEB 2
+const unsigned int TRC_L_ALW  = 1; //Should not be used
+const unsigned int TRC_L_CRI  = 2;
+const unsigned int TRC_L_ERR  = 3;
+const unsigned int TRC_L_WAR  = 4;
+const unsigned int TRC_L_NOTE = 5;
+const unsigned int TRC_L_INF  = 6;
+const unsigned int TRC_L_DEB  = 7;
 // clang-format on
 
-/// \brief get rid of annoying warning
-/// \todo See if there is a better solution than pragma
+/** @brief get rid of annoying warning
+ * @todo See if there is a better solution than pragma
+ */
 #pragma GCC system_header
 
+#define TRC_LEVEL 7
+
 #ifndef TRC_MASK
-#define TRC_MASK TRC_M_ALL
+const unsigned int USED_TRC_MASK = TRC_M_ALL;
+#else
+const unsigned int USED_TRC_MASK = TRC_MASK;
 #endif
 
 #ifndef TRC_LEVEL
-#define TRC_LEVEL TRC_L_ERR
+const unsigned int USED_TRC_LEVEL = TRC_L_ERR;
+#else
+const unsigned int USED_TRC_LEVEL = TRC_LEVEL;
 #endif
 
-#if 1
-#define XTRACE(group, level, fmt, ...)                                         \
-  (void)(((TRC_L_##level >= TRC_LEVEL) && (TRC_MASK & TRC_G_##group))          \
-             ? printf("%-3s %-20s %5d %-7s - " fmt, #level, basename((char *)__FILE__), __LINE__, \
-                      #group, ##__VA_ARGS__)                                   \
-             : 0)
+#define TRC_MASK USED_TRC_MASK
+#define TRC_LEVEL USED_TRC_LEVEL
+
+inline int Trace(int const LineNumber, char const *File, const int Group, unsigned int const SeverityLevel, const char* GroupName,  const char* SeverityName, const char *Format, ...) {
+  char *MessageBuffer = nullptr;
+  
+  va_list args;
+  va_start (args, Format);
+  __attribute__((unused)) int Characters = vasprintf(&MessageBuffer, Format, args);
+  va_end (args);
+  
+  printf("%-3s %-20s %5d %-7s - %s", SeverityName, basename((char *)File), LineNumber, GroupName, MessageBuffer);
+  
+  free(MessageBuffer);
+  return 0;
+}
+
+inline int DebugTrace(unsigned int const SeverityLevel, char const *Format, ...) {
+  char *MessageBuffer = nullptr;
+  va_list args;
+  va_start (args, Format);
+  __attribute__((unused)) int Characters = vasprintf(&MessageBuffer, Format, args);
+  va_end (args);
+  printf("%s\n", MessageBuffer);
+  free(MessageBuffer);
+  return 0;
+}
+
+#define XTRACE(Group, Level, Format, ...)                                   \
+(void)(((TRC_L_##Level >= TRC_LEVEL) && (TRC_MASK & TRC_G_##Group))          \
+? Trace(__LINE__, __FILE__, TRC_G_##Group, TRC_L_##Level, #Group, #Level, Format,\
+##__VA_ARGS__) \
+: 0)
+
 
 /// \brief Raw trace
-#define DTRACE(level, fmt, ...)                                                \
-  (void)((TRC_L_##level >= TRC_LEVEL) ? printf(fmt, ##__VA_ARGS__) : 0)
-#endif
-
-// #define XTRACE(group, level, fmt, ...)                                         \
-//   (void)(((TRC_L_##level >= TRC_LEVEL) && (TRC_MASK & TRC_G_##group))          \
-//              ? printf("%-3s %-8s" fmt, #level,\
-//                       #group, ##__VA_ARGS__)                                   \
-//              : 0)
+#define DTRACE(Level, Format, ...)                                                \
+(void)((TRC_L_##Level >= TRC_LEVEL) ? DebugTrace(TRC_L_##Level, Format, ##__VA_ARGS__) : 0)

--- a/prototype2/common/Trace.h
+++ b/prototype2/common/Trace.h
@@ -14,7 +14,7 @@
 #include <libgen.h>
 #include <stdarg.h>
 
-/** Add trace groups below - must be powers of two */
+/// Add trace groups below - must be powers of two
 // clang-format off
 const unsigned int TRC_G_INPUT   = 0x00000001U;
 const unsigned int TRC_G_OUTPUT  = 0x00000002U;
@@ -25,10 +25,10 @@ const unsigned int TRC_G_IPC     = 0x00000020U;
 const unsigned int TRC_G_CMD     = 0x00000040U;
 const unsigned int TRC_G_DATA    = 0x00000080U;
 
-/** Add trace masks below, bitwise or of grouops */
+/// Add trace masks below, bitwise or of grouops
 constexpr unsigned int TRC_M_ALL = (TRC_G_INPUT | TRC_G_OUTPUT | TRC_G_PROCESS | TRC_G_MAIN | TRC_G_INIT | TRC_G_IPC   | TRC_G_CMD | TRC_G_DATA);
 
-/** Do not edit below */
+// Do not edit below
 const unsigned int TRC_M_NONE = 0;
 
 const unsigned int TRC_L_ALW  = 1; //Should not be used
@@ -40,9 +40,8 @@ const unsigned int TRC_L_INF  = 6;
 const unsigned int TRC_L_DEB  = 7;
 // clang-format on
 
-/** @brief get rid of annoying warning
- * @todo See if there is a better solution than pragma
- */
+/// \brief get rid of annoying warning
+/// \todo See if there is a better solution than pragma
 #pragma GCC system_header
 
 #define TRC_LEVEL 6

--- a/prototype2/common/Trace.h
+++ b/prototype2/common/Trace.h
@@ -45,7 +45,7 @@ const unsigned int TRC_L_DEB  = 7;
  */
 #pragma GCC system_header
 
-#define TRC_LEVEL 7
+#define TRC_LEVEL 6
 
 #ifndef TRC_MASK
 const unsigned int USED_TRC_MASK = TRC_M_ALL;
@@ -88,7 +88,7 @@ inline int DebugTrace(unsigned int const SeverityLevel, char const *Format, ...)
 }
 
 #define XTRACE(Group, Level, Format, ...)                                   \
-(void)(((TRC_L_##Level >= TRC_LEVEL) && (TRC_MASK & TRC_G_##Group))          \
+(void)(((TRC_L_##Level <= TRC_LEVEL) && (TRC_MASK & TRC_G_##Group))          \
 ? Trace(__LINE__, __FILE__, TRC_G_##Group, TRC_L_##Level, #Group, #Level, Format,\
 ##__VA_ARGS__) \
 : 0)
@@ -96,4 +96,4 @@ inline int DebugTrace(unsigned int const SeverityLevel, char const *Format, ...)
 
 /// \brief Raw trace
 #define DTRACE(Level, Format, ...)                                                \
-(void)((TRC_L_##Level >= TRC_LEVEL) ? DebugTrace(TRC_L_##Level, Format, ##__VA_ARGS__) : 0)
+(void)((TRC_L_##Level <= TRC_LEVEL) ? DebugTrace(TRC_L_##Level, Format, ##__VA_ARGS__) : 0)

--- a/prototype2/common/Trace.h
+++ b/prototype2/common/Trace.h
@@ -90,7 +90,7 @@ inline int Trace(int const LineNumber, char const *File, const int Group, unsign
   __attribute__((unused)) int Characters = vasprintf(&MessageBuffer, Format, args);
   va_end (args);
   
-  printf("%-3s %-20s %5d %-7s - %s", SeverityName, basename((char *)File), LineNumber, GroupName, MessageBuffer);
+  printf("%-3s %-20s %5d %-7s - %s\n", SeverityName, basename((char *)File), LineNumber, GroupName, MessageBuffer);
   
   free(MessageBuffer);
   return 0;

--- a/prototype2/efu/CMakeLists.txt
+++ b/prototype2/efu/CMakeLists.txt
@@ -24,7 +24,8 @@ set(efu_INC
   )
 
 create_executable(efu)
-target_link_libraries(efu efu_common)
+target_link_libraries(efu PUBLIC efu_common)
+set_target_properties(efu PROPERTIES ENABLE_EXPORTS 1)
 get_filename_component(EFU_RUN_INSTRUCTIONS "Executing artefacts.md" ABSOLUTE)
 add_custom_command(TARGET efu POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy

--- a/prototype2/efu/CMakeLists.txt
+++ b/prototype2/efu/CMakeLists.txt
@@ -24,7 +24,6 @@ set(efu_INC
   )
 
 create_executable(efu)
-target_link_libraries(efu PUBLIC efu_common)
 set_target_properties(efu PROPERTIES ENABLE_EXPORTS 1)
 get_filename_component(EFU_RUN_INSTRUCTIONS "Executing artefacts.md" ABSOLUTE)
 add_custom_command(TARGET efu POST_BUILD

--- a/prototype2/efu/ExitHandler.cpp
+++ b/prototype2/efu/ExitHandler.cpp
@@ -31,7 +31,7 @@ void ExitHandler::nonCritical(int sig) {
 
 ExitHandler::Exit ExitHandler::HandleLastSignal() {
   if (Exit::Exit == DoExit) {
-    XTRACE(MAIN, ALW, "efu terminated with signal %d\n", LastSignal);
+    XTRACE(MAIN, ALW, "efu terminated with signal %d", LastSignal);
   }
   return DoExit;
 }

--- a/prototype2/efu/ExitHandler.h
+++ b/prototype2/efu/ExitHandler.h
@@ -8,7 +8,6 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#include <common/Trace.h>
 #include <stdlib.h>
 
 class ExitHandler {

--- a/prototype2/efu/HwCheck.cpp
+++ b/prototype2/efu/HwCheck.cpp
@@ -30,7 +30,7 @@ bool HwCheck::checkMTU(std::vector<std::string> ignore) {
   int n;
 
   if (getifaddrs(&ifaddr) == -1) {
-     XTRACE(INIT, ERR, "error getifaddrs()\n");
+     XTRACE(INIT, ERR, "error getifaddrs()");
      return false;
   }
 
@@ -52,7 +52,7 @@ bool HwCheck::checkMTU(std::vector<std::string> ignore) {
     }
 
     if (tobeignored) {
-      XTRACE(INIT, DEB, "no checking of MTU for %s\n", ifa->ifa_name);
+      XTRACE(INIT, DEB, "no checking of MTU for %s", ifa->ifa_name);
     } else {
       if (!checkMTU(ifa->ifa_name)) {
         freeifaddrs(ifaddr);
@@ -70,17 +70,17 @@ bool HwCheck::checkMTU(const char * interface) {
   struct ifreq ifr;
 
   if ((s = socket(af, SOCK_DGRAM, 0)) < 0) {
-    XTRACE(INIT, ERR, "error: socket\n");
+    XTRACE(INIT, ERR, "error: socket");
   }
 
   ifr.ifr_addr.sa_family = af;
   strcpy(ifr.ifr_name, interface);
   if (ioctl(s, SIOCGIFMTU, (caddr_t)&ifr) < 0) {
-    XTRACE(INIT, WAR, "warn: ioctl (get mtu): %s\n", ifr.ifr_name);
+    XTRACE(INIT, WAR, "warn: ioctl (get mtu): %s", ifr.ifr_name);
     return false;
   }
 
-  XTRACE(INIT, INF, "MTU of %s is %d\n", interface, ifr.ifr_mtu);
+  XTRACE(INIT, INF, "MTU of %s is %d", interface, ifr.ifr_mtu);
   close(s);
 
   return ifr.ifr_mtu >= minimumMtu;

--- a/prototype2/efu/HwCheck.cpp
+++ b/prototype2/efu/HwCheck.cpp
@@ -9,7 +9,7 @@
 
 #include <efu/HwCheck.h>
 #include <arpa/inet.h>
-#include <common/Trace.h>
+#include <common/Log.h>
 #include <cstring>
 #include <ifaddrs.h>
 #include <stdio.h>
@@ -30,7 +30,7 @@ bool HwCheck::checkMTU(std::vector<std::string> ignore) {
   int n;
 
   if (getifaddrs(&ifaddr) == -1) {
-     XTRACE(INIT, ERR, "error getifaddrs()");
+    LOG(Sev::Error, "error getifaddrs()");
      return false;
   }
 
@@ -52,7 +52,7 @@ bool HwCheck::checkMTU(std::vector<std::string> ignore) {
     }
 
     if (tobeignored) {
-      XTRACE(INIT, DEB, "no checking of MTU for %s", ifa->ifa_name);
+      LOG(Sev::Debug, "no checking of MTU for {}", ifa->ifa_name);
     } else {
       if (!checkMTU(ifa->ifa_name)) {
         freeifaddrs(ifaddr);
@@ -70,17 +70,17 @@ bool HwCheck::checkMTU(const char * interface) {
   struct ifreq ifr;
 
   if ((s = socket(af, SOCK_DGRAM, 0)) < 0) {
-    XTRACE(INIT, ERR, "error: socket");
+    LOG(Sev::Error, "error: socket");
   }
 
   ifr.ifr_addr.sa_family = af;
   strcpy(ifr.ifr_name, interface);
   if (ioctl(s, SIOCGIFMTU, (caddr_t)&ifr) < 0) {
-    XTRACE(INIT, WAR, "warn: ioctl (get mtu): %s", ifr.ifr_name);
+    LOG(Sev::Warning, "warn: ioctl (get mtu): {}", ifr.ifr_name);
     return false;
   }
 
-  XTRACE(INIT, INF, "MTU of %s is %d", interface, ifr.ifr_mtu);
+  LOG(Sev::Info, "MTU of {} is {}", interface, ifr.ifr_mtu);
   close(s);
 
   return ifr.ifr_mtu >= minimumMtu;

--- a/prototype2/efu/Launcher.cpp
+++ b/prototype2/efu/Launcher.cpp
@@ -3,7 +3,7 @@
 #include <cassert>
 #include <common/Detector.h>
 #include <common/EFUArgs.h>
-#include <common/Trace.h>
+#include <common/Log.h>
 #include <efu/Launcher.h>
 #include <iostream>
 #include <map>
@@ -11,10 +11,9 @@
 
 void Launcher::launchThreads(std::shared_ptr<Detector> &detector) {
   auto startThreadsWithoutAffinity = [&detector]() {
-    XTRACE(MAIN, ALW, "Launching threads without core affinity.");
+    LOG(Sev::Info, "Launching threads without core affinity.");
     for (auto &ThreadInfo : detector->GetThreadInfo()) {
-      XTRACE(MAIN, ALW, "Creating new thread (id: %s)",
-             ThreadInfo.name.c_str());
+      LOG(Sev::Debug, "Creating new thread (id: {})", ThreadInfo.name);
       ThreadInfo.thread = std::thread(ThreadInfo.func);
     }
   };
@@ -25,15 +24,14 @@ void Launcher::launchThreads(std::shared_ptr<Detector> &detector) {
     cpu_set_t cpuset;
     CPU_ZERO(&cpuset);
     CPU_SET(core, &cpuset);
-    XTRACE(MAIN, ALW, "Setting thread affinity to core %d", core);
-    GLOG_INF("Setting thread affinity to core " + std::to_string(core));
+    LOG(Sev::Debug, "Setting thread affinity to core {}", core);
 
     int __attribute__((unused)) s = pthread_setaffinity_np(
         thread.native_handle(), sizeof(cpu_set_t), &cpuset);
     assert(s == 0);
 #else
 #pragma message("setaffinity only implemented for Linux")
-    GLOG_WAR("setaffinity only implemented for Linux");
+    LOG(Sev::Notice, "setaffinity only implemented for Linux");
 #endif
   };
 
@@ -45,27 +43,24 @@ void Launcher::launchThreads(std::shared_ptr<Detector> &detector) {
     startThreadsWithoutAffinity();
   } else if (1 == ThreadCoreAffinity.size() and
              ThreadCoreAffinity[0].Name == "implicit_affinity") {
-    XTRACE(MAIN, ALW, "Launching threads with implicit core affinity.");
+    LOG(Sev::Info, "Launching threads with implicit core affinity.");
     int CoreCounter = ThreadCoreAffinity[0].Core;
     for (auto &ThreadInfo : detector->GetThreadInfo()) {
-      XTRACE(MAIN, ALW, "Creating new thread (id: %s)",
-             ThreadInfo.name.c_str());
+      LOG(Sev::Debug, "Creating new thread (id: {})", ThreadInfo.name);
       ThreadInfo.thread = std::thread(ThreadInfo.func);
       setThreadCoreAffinity(ThreadInfo.thread, CoreCounter++);
     }
   } else {
-    XTRACE(MAIN, ALW, "Launching threads with explicit core affinity.");
+    LOG(Sev::Info, "Launching threads with explicit core affinity.");
     for (auto &ThreadInfo : detector->GetThreadInfo()) {
-      XTRACE(MAIN, ALW, "Creating new thread (id: %s)",
-             ThreadInfo.name.c_str());
+      LOG(Sev::Debug, "Creating new thread (id: {})", ThreadInfo.name);
       ThreadInfo.thread = std::thread(ThreadInfo.func);
       if (1 == AffinityMap.count(ThreadInfo.name)) {
         setThreadCoreAffinity(ThreadInfo.thread, AffinityMap[ThreadInfo.name]);
       } else {
-        XTRACE(MAIN, ALW,
+        LOG(Sev::Notice,
                "No thread core affinity information available for thread with "
-               "id: %s",
-               ThreadInfo.name.c_str());
+               "id: {}", ThreadInfo.name);
       }
     }
   }

--- a/prototype2/efu/Launcher.cpp
+++ b/prototype2/efu/Launcher.cpp
@@ -11,9 +11,9 @@
 
 void Launcher::launchThreads(std::shared_ptr<Detector> &detector) {
   auto startThreadsWithoutAffinity = [&detector]() {
-    XTRACE(MAIN, ALW, "Launching threads without core affinity.\n");
+    XTRACE(MAIN, ALW, "Launching threads without core affinity.");
     for (auto &ThreadInfo : detector->GetThreadInfo()) {
-      XTRACE(MAIN, ALW, "Creating new thread (id: %s)\n",
+      XTRACE(MAIN, ALW, "Creating new thread (id: %s)",
              ThreadInfo.name.c_str());
       ThreadInfo.thread = std::thread(ThreadInfo.func);
     }
@@ -25,7 +25,7 @@ void Launcher::launchThreads(std::shared_ptr<Detector> &detector) {
     cpu_set_t cpuset;
     CPU_ZERO(&cpuset);
     CPU_SET(core, &cpuset);
-    XTRACE(MAIN, ALW, "Setting thread affinity to core %d\n", core);
+    XTRACE(MAIN, ALW, "Setting thread affinity to core %d", core);
     GLOG_INF("Setting thread affinity to core " + std::to_string(core));
 
     int __attribute__((unused)) s = pthread_setaffinity_np(
@@ -45,18 +45,18 @@ void Launcher::launchThreads(std::shared_ptr<Detector> &detector) {
     startThreadsWithoutAffinity();
   } else if (1 == ThreadCoreAffinity.size() and
              ThreadCoreAffinity[0].Name == "implicit_affinity") {
-    XTRACE(MAIN, ALW, "Launching threads with implicit core affinity.\n");
+    XTRACE(MAIN, ALW, "Launching threads with implicit core affinity.");
     int CoreCounter = ThreadCoreAffinity[0].Core;
     for (auto &ThreadInfo : detector->GetThreadInfo()) {
-      XTRACE(MAIN, ALW, "Creating new thread (id: %s)\n",
+      XTRACE(MAIN, ALW, "Creating new thread (id: %s)",
              ThreadInfo.name.c_str());
       ThreadInfo.thread = std::thread(ThreadInfo.func);
       setThreadCoreAffinity(ThreadInfo.thread, CoreCounter++);
     }
   } else {
-    XTRACE(MAIN, ALW, "Launching threads with explicit core affinity.\n");
+    XTRACE(MAIN, ALW, "Launching threads with explicit core affinity.");
     for (auto &ThreadInfo : detector->GetThreadInfo()) {
-      XTRACE(MAIN, ALW, "Creating new thread (id: %s)\n",
+      XTRACE(MAIN, ALW, "Creating new thread (id: %s)",
              ThreadInfo.name.c_str());
       ThreadInfo.thread = std::thread(ThreadInfo.func);
       if (1 == AffinityMap.count(ThreadInfo.name)) {
@@ -64,7 +64,7 @@ void Launcher::launchThreads(std::shared_ptr<Detector> &detector) {
       } else {
         XTRACE(MAIN, ALW,
                "No thread core affinity information available for thread with "
-               "id: %s\n",
+               "id: %s",
                ThreadInfo.name.c_str());
       }
     }

--- a/prototype2/efu/Loader.cpp
+++ b/prototype2/efu/Loader.cpp
@@ -9,7 +9,7 @@
 #include <string>
 
 Loader::~Loader() {
-  XTRACE(INIT, ALW, "Loader destructor called\n");
+  XTRACE(INIT, ALW, "Loader destructor called");
   // Remove pointer before closing the handle to prevent accessing freed memory
   unloadPlugin();
 }
@@ -47,20 +47,20 @@ bool Loader::loadPlugin(const std::string lib) {
     }
   }
   if (handle == nullptr) {
-    XTRACE(INIT, CRI, "Could not open library %s: %s\n", lib.c_str(),
+    XTRACE(INIT, CRI, "Could not open library %s: %s", lib.c_str(),
            dlerror());
     return false;
   }
 
   if (!(myFactory = (DetectorFactoryBase *)dlsym(handle, "Factory"))) {
-    XTRACE(INIT, CRI, "Could not find Factory in %s\n", lib.c_str());
+    XTRACE(INIT, CRI, "Could not find Factory in %s", lib.c_str());
     return false;
   }
 
   PopulateCLIParser *tempParserPopulator =
       (PopulateCLIParser *)dlsym(handle, "PopulateParser");
   if (nullptr == tempParserPopulator) {
-    XTRACE(INIT, WAR, "Unable to find function to populate CLI parser in %s\n",
+    XTRACE(INIT, WAR, "Unable to find function to populate CLI parser in %s",
            lib.c_str());
   } else {
     if (nullptr == tempParserPopulator->Function) {

--- a/prototype2/efu/Parser.cpp
+++ b/prototype2/efu/Parser.cpp
@@ -18,10 +18,10 @@ static int stat_get_count(std::vector<std::string> cmdargs, char *output,
                           unsigned int *obytes,
                           std::shared_ptr<Detector> detector) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "STAT_GET_COUNT\n");
+  XTRACE(CMD, INF, "STAT_GET_COUNT");
   GLOG_INF("STAT_GET_COUNT");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "STAT_GET_COUNT: wrong number of arguments\n");
+    XTRACE(CMD, WAR, "STAT_GET_COUNT: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -35,10 +35,10 @@ static int stat_get_count(std::vector<std::string> cmdargs, char *output,
 static int stat_get(std::vector<std::string> cmdargs, char *output,
                     unsigned int *obytes, std::shared_ptr<Detector> detector) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "STAT_GET\n");
+  XTRACE(CMD, INF, "STAT_GET");
   GLOG_INF("STAT_GET");
   if (nargs != 2) {
-    XTRACE(CMD, WAR, "STAT_GET: wrong number of arguments\n");
+    XTRACE(CMD, WAR, "STAT_GET: wrong number of arguments");
     return -Parser::EBADARGS;
   }
   auto index = atoi(cmdargs.at(1).c_str());
@@ -55,10 +55,10 @@ static int stat_get(std::vector<std::string> cmdargs, char *output,
 static int version_get(std::vector<std::string> cmdargs, char *output,
                        unsigned int *obytes) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "VERSION_GET\n");
+  XTRACE(CMD, INF, "VERSION_GET");
   GLOG_INF("VERSION_GET");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "VERSION_GET: wrong number of arguments\n");
+    XTRACE(CMD, WAR, "VERSION_GET: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -73,10 +73,10 @@ static int cmd_get_count(std::vector<std::string> cmdargs, char *output,
                        unsigned int *obytes,
                        int count) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "CMD_GET_COUNT\n");
+  XTRACE(CMD, INF, "CMD_GET_COUNT");
   GLOG_INF("CMD_GET_COUNT");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "CMD_GET_COUNT: wrong number of arguments\n");
+    XTRACE(CMD, WAR, "CMD_GET_COUNT: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -90,16 +90,16 @@ static int cmd_get(std::vector<std::string> cmdargs, char *output,
                        unsigned int *obytes,
                        Parser * parser) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "CMD_GET\n");
+  XTRACE(CMD, INF, "CMD_GET");
   GLOG_INF("CMD_GET");
   if (nargs != 2) {
-    XTRACE(CMD, WAR, "CMD_GET: wrong number of arguments\n");
+    XTRACE(CMD, WAR, "CMD_GET: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
   size_t index = atoi(cmdargs.at(1).c_str());
   if (index < 1 || index > parser->commands.size()) {
-    XTRACE(CMD, WAR, "CMD_GET: command index %lu, out of range (1 - %lu)\n", index, parser->commands.size());
+    XTRACE(CMD, WAR, "CMD_GET: command index %lu, out of range (1 - %lu)", index, parser->commands.size());
     return -Parser::EBADARGS;
   }
 
@@ -116,10 +116,10 @@ static int detector_info_get(std::vector<std::string> cmdargs, char *output,
                              unsigned int *obytes,
                              std::shared_ptr<Detector> detector) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "DETECTOR_INFO_GET\n");
+  XTRACE(CMD, INF, "DETECTOR_INFO_GET");
   GLOG_INF("DETECTOR_INFO_GET");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "DETECTOR_INFO_GET: wrong number of arguments\n");
+    XTRACE(CMD, WAR, "DETECTOR_INFO_GET: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -133,14 +133,14 @@ static int detector_info_get(std::vector<std::string> cmdargs, char *output,
 static int efu_exit(std::vector<std::string> cmdargs, UNUSED char *output,
                     UNUSED unsigned int *obytes, int &keep_running) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "EXIT\n");
+  XTRACE(CMD, INF, "EXIT");
   GLOG_INF("EXIT");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "EXIT: wrong number of arguments\n");
+    XTRACE(CMD, WAR, "EXIT: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
-  XTRACE(CMD, INF, "Sending TERMINATE command to EFU\n");
+  XTRACE(CMD, INF, "Sending TERMINATE command to EFU");
   keep_running = 0;
 
   return Parser::OK;
@@ -168,7 +168,7 @@ Parser::Parser(std::shared_ptr<Detector> detector, int &keep_running) {
   });
 
   if (detector == nullptr) {
-    XTRACE(CMD, ALW, "No detector specified, no detector commands loaded\n");
+    XTRACE(CMD, ALW, "No detector specified, no detector commands loaded");
     return;
   }
 
@@ -194,10 +194,10 @@ Parser::Parser(std::shared_ptr<Detector> detector, int &keep_running) {
 }
 
 int Parser::registercmd(std::string cmd_name, cmdFunction cmd_fn) {
-  XTRACE(CMD, INF, "Registering command: %s\n", cmd_name.c_str());
+  XTRACE(CMD, INF, "Registering command: %s", cmd_name.c_str());
   GLOG_INF("Registering command: " + cmd_name);
   if (commands[cmd_name] != 0) {
-    XTRACE(CMD, WAR, "Command already exist: %s\n", cmd_name.c_str());
+    XTRACE(CMD, WAR, "Command already exist: %s", cmd_name.c_str());
     GLOG_WAR("Command already exist: " + cmd_name);
     return -1;
   }
@@ -207,7 +207,7 @@ int Parser::registercmd(std::string cmd_name, cmdFunction cmd_fn) {
 
 int Parser::parse(char *input, unsigned int ibytes, char *output,
                   unsigned int *obytes) {
-  XTRACE(CMD, DEB, "parse() received %u bytes\n", ibytes);
+  XTRACE(CMD, DEB, "parse() received %u bytes", ibytes);
   *obytes = 0;
   memset(output, 0, SERVER_BUFFER_SIZE);
 
@@ -221,7 +221,7 @@ int Parser::parse(char *input, unsigned int ibytes, char *output,
   }
 
   if (input[ibytes - 1] != '\0') {
-    XTRACE(CMD, DEB, "adding null termination\n");
+    XTRACE(CMD, DEB, "adding null termination");
     auto end = std::min(ibytes, SERVER_BUFFER_SIZE - 1);
     input[end] = '\0';
   }
@@ -235,31 +235,31 @@ int Parser::parse(char *input, unsigned int ibytes, char *output,
   }
 
   if ((int)tokens.size() < 1) {
-    XTRACE(CMD, WAR, "No tokens\n");
+    XTRACE(CMD, WAR, "No tokens");
     *obytes = snprintf(output, SERVER_BUFFER_SIZE, "Error: <BADCMD>");
     return -ENOTOKENS;
   }
 
-  XTRACE(CMD, DEB, "Tokens in command: %d\n", (int)tokens.size());
+  XTRACE(CMD, DEB, "Tokens in command: %d", (int)tokens.size());
   for (auto token : tokens) {
-    XTRACE(CMD, INF, "Token: %s\n", token.c_str());
+    XTRACE(CMD, INF, "Token: %s", token.c_str());
   }
 
   auto command = tokens.at(0);
   int res = -EBADCMD;
 
   if ((commands[command] != 0) && (command.size() < max_command_size)) {
-    XTRACE(CMD, INF, "Calling registered command %s\n", command.c_str());
+    XTRACE(CMD, INF, "Calling registered command %s", command.c_str());
     res = commands[command](tokens, output, obytes);
   }
 
-  XTRACE(CMD, DEB, "parse1 res: %d, obytes: %d\n", res, *obytes);
+  XTRACE(CMD, DEB, "parse1 res: %d, obytes: %d", res, *obytes);
   if (*obytes == 0) { // no  reply specified, create one
 
     assert((res == OK) || (res == -ENOTOKENS) || (res == -EBADCMD) ||
            (res == -EBADARGS));
 
-    XTRACE(CMD, INF, "creating response\n");
+    XTRACE(CMD, INF, "creating response");
     switch (res) {
     case OK:
       *obytes = snprintf(output, SERVER_BUFFER_SIZE, "<OK>");
@@ -273,7 +273,7 @@ int Parser::parse(char *input, unsigned int ibytes, char *output,
       break;
     }
   }
-  XTRACE(CMD, DEB, "parse2 res: %d, obytes: %d\n", res, *obytes);
+  XTRACE(CMD, DEB, "parse2 res: %d, obytes: %d", res, *obytes);
   return res;
 }
 

--- a/prototype2/efu/Parser.cpp
+++ b/prototype2/efu/Parser.cpp
@@ -2,7 +2,7 @@
 
 #include <cassert>
 #include <common/EFUArgs.h>
-#include <common/Trace.h>
+#include <common/Log.h>
 #include <common/Version.h>
 #include <cstring>
 #include <efu/Parser.h>
@@ -18,10 +18,9 @@ static int stat_get_count(std::vector<std::string> cmdargs, char *output,
                           unsigned int *obytes,
                           std::shared_ptr<Detector> detector) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "STAT_GET_COUNT");
-  GLOG_INF("STAT_GET_COUNT");
+  LOG(Sev::Debug, "STAT_GET_COUNT");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "STAT_GET_COUNT: wrong number of arguments");
+    LOG(Sev::Warning, "STAT_GET_COUNT: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -35,10 +34,9 @@ static int stat_get_count(std::vector<std::string> cmdargs, char *output,
 static int stat_get(std::vector<std::string> cmdargs, char *output,
                     unsigned int *obytes, std::shared_ptr<Detector> detector) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "STAT_GET");
-  GLOG_INF("STAT_GET");
+  LOG(Sev::Debug, "STAT_GET");
   if (nargs != 2) {
-    XTRACE(CMD, WAR, "STAT_GET: wrong number of arguments");
+    LOG(Sev::Warning, "STAT_GET: wrong number of arguments");
     return -Parser::EBADARGS;
   }
   auto index = atoi(cmdargs.at(1).c_str());
@@ -55,10 +53,9 @@ static int stat_get(std::vector<std::string> cmdargs, char *output,
 static int version_get(std::vector<std::string> cmdargs, char *output,
                        unsigned int *obytes) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "VERSION_GET");
-  GLOG_INF("VERSION_GET");
+  LOG(Sev::Debug, "VERSION_GET");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "VERSION_GET: wrong number of arguments");
+    LOG(Sev::Warning, "VERSION_GET: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -73,10 +70,9 @@ static int cmd_get_count(std::vector<std::string> cmdargs, char *output,
                        unsigned int *obytes,
                        int count) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "CMD_GET_COUNT");
-  GLOG_INF("CMD_GET_COUNT");
+  LOG(Sev::Debug, "CMD_GET_COUNT");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "CMD_GET_COUNT: wrong number of arguments");
+    LOG(Sev::Warning, "CMD_GET_COUNT: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -90,16 +86,15 @@ static int cmd_get(std::vector<std::string> cmdargs, char *output,
                        unsigned int *obytes,
                        Parser * parser) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "CMD_GET");
-  GLOG_INF("CMD_GET");
+  LOG(Sev::Debug, "CMD_GET");
   if (nargs != 2) {
-    XTRACE(CMD, WAR, "CMD_GET: wrong number of arguments");
+    LOG(Sev::Warning, "CMD_GET: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
   size_t index = atoi(cmdargs.at(1).c_str());
   if (index < 1 || index > parser->commands.size()) {
-    XTRACE(CMD, WAR, "CMD_GET: command index %lu, out of range (1 - %lu)", index, parser->commands.size());
+    LOG(Sev::Warning, "CMD_GET: command index {}, out of range (1 - {})", index, parser->commands.size());
     return -Parser::EBADARGS;
   }
 
@@ -116,10 +111,9 @@ static int detector_info_get(std::vector<std::string> cmdargs, char *output,
                              unsigned int *obytes,
                              std::shared_ptr<Detector> detector) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "DETECTOR_INFO_GET");
-  GLOG_INF("DETECTOR_INFO_GET");
+  LOG(Sev::Debug, "DETECTOR_INFO_GET");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "DETECTOR_INFO_GET: wrong number of arguments");
+    LOG(Sev::Warning, "DETECTOR_INFO_GET: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -133,14 +127,13 @@ static int detector_info_get(std::vector<std::string> cmdargs, char *output,
 static int efu_exit(std::vector<std::string> cmdargs, UNUSED char *output,
                     UNUSED unsigned int *obytes, int &keep_running) {
   auto nargs = cmdargs.size();
-  XTRACE(CMD, INF, "EXIT");
-  GLOG_INF("EXIT");
+  LOG(Sev::Debug, "EXIT");
   if (nargs != 1) {
-    XTRACE(CMD, WAR, "EXIT: wrong number of arguments");
+    LOG(Sev::Warning, "EXIT: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
-  XTRACE(CMD, INF, "Sending TERMINATE command to EFU");
+  LOG(Sev::Info, "Sending TERMINATE command to EFU");
   keep_running = 0;
 
   return Parser::OK;
@@ -168,7 +161,7 @@ Parser::Parser(std::shared_ptr<Detector> detector, int &keep_running) {
   });
 
   if (detector == nullptr) {
-    XTRACE(CMD, ALW, "No detector specified, no detector commands loaded");
+    LOG(Sev::Debug, "No detector specified, no detector commands loaded");
     return;
   }
 
@@ -194,11 +187,9 @@ Parser::Parser(std::shared_ptr<Detector> detector, int &keep_running) {
 }
 
 int Parser::registercmd(std::string cmd_name, cmdFunction cmd_fn) {
-  XTRACE(CMD, INF, "Registering command: %s", cmd_name.c_str());
-  GLOG_INF("Registering command: " + cmd_name);
+  LOG(Sev::Debug, "Registering command: {}", cmd_name);
   if (commands[cmd_name] != 0) {
-    XTRACE(CMD, WAR, "Command already exist: %s", cmd_name.c_str());
-    GLOG_WAR("Command already exist: " + cmd_name);
+    LOG(Sev::Warning, "Command already exist: {}", cmd_name);
     return -1;
   }
   commands[cmd_name] = cmd_fn;
@@ -207,7 +198,7 @@ int Parser::registercmd(std::string cmd_name, cmdFunction cmd_fn) {
 
 int Parser::parse(char *input, unsigned int ibytes, char *output,
                   unsigned int *obytes) {
-  XTRACE(CMD, DEB, "parse() received %u bytes", ibytes);
+  LOG(Sev::Debug, "parse() received {} bytes", ibytes);
   *obytes = 0;
   memset(output, 0, SERVER_BUFFER_SIZE);
 
@@ -221,7 +212,7 @@ int Parser::parse(char *input, unsigned int ibytes, char *output,
   }
 
   if (input[ibytes - 1] != '\0') {
-    XTRACE(CMD, DEB, "adding null termination");
+    LOG(Sev::Debug, "adding null termination");
     auto end = std::min(ibytes, SERVER_BUFFER_SIZE - 1);
     input[end] = '\0';
   }
@@ -235,31 +226,31 @@ int Parser::parse(char *input, unsigned int ibytes, char *output,
   }
 
   if ((int)tokens.size() < 1) {
-    XTRACE(CMD, WAR, "No tokens");
+    LOG(Sev::Warning, "No tokens");
     *obytes = snprintf(output, SERVER_BUFFER_SIZE, "Error: <BADCMD>");
     return -ENOTOKENS;
   }
 
-  XTRACE(CMD, DEB, "Tokens in command: %d", (int)tokens.size());
+  LOG(Sev::Debug, "Tokens in command: {}", (int)tokens.size());
   for (auto token : tokens) {
-    XTRACE(CMD, INF, "Token: %s", token.c_str());
+    LOG(Sev::Debug, "Token: {}", token);
   }
 
   auto command = tokens.at(0);
   int res = -EBADCMD;
 
   if ((commands[command] != 0) && (command.size() < max_command_size)) {
-    XTRACE(CMD, INF, "Calling registered command %s", command.c_str());
+    LOG(Sev::Debug, "Calling registered command {}", command);
     res = commands[command](tokens, output, obytes);
   }
 
-  XTRACE(CMD, DEB, "parse1 res: %d, obytes: %d", res, *obytes);
+  LOG(Sev::Debug, "parse1 res: {}, obytes: {}", res, *obytes);
   if (*obytes == 0) { // no  reply specified, create one
 
     assert((res == OK) || (res == -ENOTOKENS) || (res == -EBADCMD) ||
            (res == -EBADARGS));
 
-    XTRACE(CMD, INF, "creating response");
+    LOG(Sev::Debug, "creating response");
     switch (res) {
     case OK:
       *obytes = snprintf(output, SERVER_BUFFER_SIZE, "<OK>");
@@ -273,7 +264,7 @@ int Parser::parse(char *input, unsigned int ibytes, char *output,
       break;
     }
   }
-  XTRACE(CMD, DEB, "parse2 res: %d, obytes: %d", res, *obytes);
+  LOG(Sev::Debug, "parse2 res: {}, obytes: {}", res, *obytes);
   return res;
 }
 

--- a/prototype2/efu/Server.cpp
+++ b/prototype2/efu/Server.cpp
@@ -41,7 +41,7 @@ Server::Server(int port, Parser &parse) : port_(port), parser(parse) {
 }
 
 void Server::server_close(int socket) {
-  XTRACE(IPC, DEB, "Closing socket fd %d\n", socket);
+  XTRACE(IPC, DEB, "Closing socket fd %d", socket);
   close(socket);
   auto client = std::find(clientfd.begin(), clientfd.end(), socket);
   assert(client != clientfd.end());
@@ -51,7 +51,7 @@ void Server::server_close(int socket) {
 /** \brief Setup socket parameters
  */
 void Server::server_open() {
-  XTRACE(IPC, INF, "Server::open() called on port %d\n", port_);
+  XTRACE(IPC, INF, "Server::open() called on port %d", port_);
 
   struct sockaddr_in socket_address;
   UNUSED int ret;
@@ -82,9 +82,9 @@ void Server::server_open() {
 }
 
 int Server::server_send(int socketfd) {
-  XTRACE(IPC, DEB, "server_send() - %d bytes\n", output.bytes);
+  XTRACE(IPC, DEB, "server_send() - %d bytes", output.bytes);
   if (send(socketfd, output.buffer, output.bytes, 0) < 0) {
-    XTRACE(IPC, WAR, "Error sending command reply\n");
+    XTRACE(IPC, WAR, "Error sending command reply");
     return -1;
   }
   output.bytes = 0;
@@ -115,17 +115,17 @@ void Server::server_poll() {
   if (ready > 0 && FD_ISSET(serverfd, &fd_working)) {
     auto freefd = std::find(clientfd.begin(), clientfd.end(), -1);
     if (freefd == clientfd.end()) {
-      XTRACE(IPC, WAR, "Max clients connected, can't accept()\n");
+      XTRACE(IPC, WAR, "Max clients connected, can't accept()");
       auto tmpsock = accept(serverfd, NULL, NULL);
       close(tmpsock);
     } else {
-      XTRACE(IPC, INF, "Accept new connection\n");
+      XTRACE(IPC, INF, "Accept new connection");
       *freefd = accept(serverfd, NULL, NULL);
       if (*freefd < 0 && errno != EWOULDBLOCK) {
         assert(1 == 0);
       }
       FD_SET(*freefd, &fd_master);
-      XTRACE(IPC, DEB, "New clent socket: %d, ready: %d\n", *freefd, ready);
+      XTRACE(IPC, DEB, "New clent socket: %d, ready: %d", *freefd, ready);
     }
     ready--;
   }
@@ -137,31 +137,31 @@ void Server::server_poll() {
                         SERVER_BUFFER_SIZE - input.bytes, 0);
 
       if ((bytes < 0) && (errno != EWOULDBLOCK || errno != EAGAIN)) {
-        XTRACE(IPC, WAR, "recv() failed, errno: %d\n", errno);
+        XTRACE(IPC, WAR, "recv() failed, errno: %d", errno);
         perror("recv() failed");
         server_close(cli);
         return;
       }
       if (bytes == 0) {
-        XTRACE(IPC, INF, "Peer closed socket %d\n", cli);
+        XTRACE(IPC, INF, "Peer closed socket %d", cli);
         server_close(cli);
         return;
       }
-      XTRACE(IPC, INF, "Received %ld bytes on socket %d\n", bytes, cli);
+      XTRACE(IPC, INF, "Received %ld bytes on socket %d", bytes, cli);
       input.bytes += bytes;
 
       assert(input.bytes <= SERVER_BUFFER_SIZE);
-      XTRACE(IPC, DEB, "input.bytes: %d\n", input.bytes);
+      XTRACE(IPC, DEB, "input.bytes: %d", input.bytes);
 
       // Parse and generate reply
       if (parser.parse((char *)input.buffer, input.bytes, (char *)output.buffer,
                        &output.bytes) < 0) {
-        XTRACE(IPC, WAR, "Parse error\n");
+        XTRACE(IPC, WAR, "Parse error");
       }
       input.bytes = 0;
       input.data = input.buffer;
       if (server_send(cli) < 0) {
-        XTRACE(IPC, WAR, "server_send() failed\n");
+        XTRACE(IPC, WAR, "server_send() failed");
         server_close(cli);
         return;
       }

--- a/prototype2/efu/main.cpp
+++ b/prototype2/efu/main.cpp
@@ -69,27 +69,27 @@ int main(int argc, char *argv[]) {
   GLOG_INF("Starting Event Formation Unit");
   GLOG_INF("Event Formation Unit version: " + efu_version());
   GLOG_INF("Event Formation Unit build: " + efu_buildstr());
-  XTRACE(MAIN, ALW, "Starting Event Formation unit\n");
-  XTRACE(MAIN, ALW, "Event Formation Software Version: %s\n",
+  XTRACE(MAIN, ALW, "Starting Event Formation unit");
+  XTRACE(MAIN, ALW, "Event Formation Software Version: %s",
          efu_version().c_str());
-  XTRACE(MAIN, ALW, "Event Formation Unit build: %s\n", EFU_STR(BUILDSTR));
+  XTRACE(MAIN, ALW, "Event Formation Unit build: %s", EFU_STR(BUILDSTR));
 
   if (hwcheck.checkMTU(hwcheck.defaultIgnoredInterfaces) == false) {
-    XTRACE(MAIN, ERR, "MTU checks failed, for a quick fix, try\n");
-    XTRACE(MAIN, ERR, "sudo ifconfig eth0 mtu 9000 (change eth0 to match your system)\n");
-    XTRACE(MAIN, ERR, "exiting...\n");
+    XTRACE(MAIN, ERR, "MTU checks failed, for a quick fix, try");
+    XTRACE(MAIN, ERR, "sudo ifconfig eth0 mtu 9000 (change eth0 to match your system)");
+    XTRACE(MAIN, ERR, "exiting...");
     GLOG_ERR("MTU checks failed, exiting.");
     return 1;
   }
 
   if (DetectorSettings.StopAfterSec == 0) {
-    XTRACE(MAIN, ALW, "Event Formation Unit Exit (Immediate)\n");
+    XTRACE(MAIN, ALW, "Event Formation Unit Exit (Immediate)");
     GLOG_INF("Event Formation Unit Exit (Immediate)");
     return 0;
   }
 
 
-  XTRACE(MAIN, ALW, "Launching EFU as Instrument %s\n", DetectorName.c_str());
+  XTRACE(MAIN, ALW, "Launching EFU as Instrument %s", DetectorName.c_str());
 
   Launcher launcher(AffinitySettings);
 
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
     //Do not allow immediate exits
     if (RunTimer.timeus() >= (uint64_t)ONE_SECOND_US / 10) {
       if (keep_running == 0) {
-        XTRACE(INIT, ALW, "Application stop, Exiting...\n");
+        XTRACE(INIT, ALW, "Application stop, Exiting...");
         detector->stopThreads();
         sleep(1);
         break;
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
 
     if (RunTimer.timeus() >=
         DetectorSettings.StopAfterSec * (uint64_t)ONE_SECOND_US) {
-      XTRACE(MAIN, ALW, "Application timeout, Exiting...\n");
+      XTRACE(MAIN, ALW, "Application timeout, Exiting...");
       GLOG_INF("Event Formation Unit Exiting (User timeout)");
       detector->stopThreads();
       sleep(1);
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
   if (detector.use_count() > 1) {
     XTRACE(MAIN, WAR,
            "There are more than 1 strong pointers to the detector. This "
-           "application may crash on exit.\n");
+           "application may crash on exit.");
   }
   detector.reset();
 

--- a/prototype2/efu/main.cpp
+++ b/prototype2/efu/main.cpp
@@ -17,6 +17,11 @@
 
 #define ONE_SECOND_US 1000000U
 
+std::string ConsoleFormatter(const LogMessage &msg) {
+  static const std::vector<std::string> SevToString{"EMG", "ALR", "CRI", "ERR", "WAR", "NOTE", "INF", "DEB"};
+  return fmt::format("{:5}{:21}{:5} - {}", SevToString.at(int(msg.severity)), basename((char*)msg.additionalFields[0].second.strVal.c_str()), msg.additionalFields[1].second.intVal, msg.message);
+}
+
 /** Load detector, launch pipeline threads, then sleep until timeout or break */
 int main(int argc, char *argv[]) {
   BaseSettings DetectorSettings;
@@ -33,6 +38,12 @@ int main(int argc, char *argv[]) {
       return 0;
     }
     // Set-up logging before we start doing important stuff
+    Log::RemoveAllHandlers();
+    
+    auto CI = new ConsoleInterface();
+    CI->SetMessageStringCreatorFunction(ConsoleFormatter);
+    Log::AddLogHandler(CI);
+    
     Log::SetMinimumSeverity(Severity(efu_args.getLogLevel()));
     Log::AddLogHandler(new GraylogInterface(GLConfig.address, GLConfig.port));
     if (efu_args.getLogFileName().size() > 0) {

--- a/prototype2/efu/main.cpp
+++ b/prototype2/efu/main.cpp
@@ -17,9 +17,18 @@
 
 #define ONE_SECOND_US 1000000U
 
-std::string ConsoleFormatter(const LogMessage &msg) {
+std::string ConsoleFormatter(const LogMessage &Msg) {
   static const std::vector<std::string> SevToString{"EMG", "ALR", "CRI", "ERR", "WAR", "NOTE", "INF", "DEB"};
-  return fmt::format("{:5}{:21}{:5} - {}", SevToString.at(int(msg.severity)), basename((char*)msg.additionalFields[0].second.strVal.c_str()), msg.additionalFields[1].second.intVal, msg.message);
+  std::string FileName;
+  std::int64_t LineNr = -1;
+  for (auto &CField : Msg.additionalFields) {
+    if (CField.first == "file") {
+      FileName = CField.second.strVal;
+    } else if (CField.first == "line") {
+      LineNr = CField.second.intVal;
+    }
+  }
+  return fmt::format("{:5}{:21}{:5} - {}", SevToString.at(int(Msg.severity)), FileName, LineNr, Msg.message);
 }
 
 /** Load detector, launch pipeline threads, then sleep until timeout or break */

--- a/prototype2/gdgem/NMXConfig.cpp
+++ b/prototype2/gdgem/NMXConfig.cpp
@@ -18,7 +18,7 @@ NMXConfig::NMXConfig(std::string jsonfile) {
                   std::istreambuf_iterator<char>());
 
   if (!reader.parse(str, root, 0)) {
-    XTRACE(INIT, WAR, "Invalid Json file: %s\n", jsonfile.c_str());
+    XTRACE(INIT, WAR, "Invalid Json file: %s", jsonfile.c_str());
     return;
   }
 

--- a/prototype2/gdgem/clustering/DoroClusterer.cpp
+++ b/prototype2/gdgem/clustering/DoroClusterer.cpp
@@ -69,7 +69,7 @@ void DoroClusterer::stash_cluster(Cluster &cluster) {
   if (cluster.entries.size() < pMinClusterSize)
     return;
 
-  DTRACE(DEB, "******** VALID ********\n");
+  DTRACE(DEB, "******** VALID ********");
   clusters.emplace_back(std::move(cluster));
   stats_cluster_count++;
 }

--- a/prototype2/gdgem/clustering/HitSorter.cpp
+++ b/prototype2/gdgem/clustering/HitSorter.cpp
@@ -44,7 +44,7 @@ void HitSorter::insert(const Readout &readout) {
       pTime.trigger_timestamp_ns(readout.srs_timestamp + readout.bonus_timestamp);
 
   if (requires_analysis(triggerTimestamp_ns)) {
-    XTRACE(PROCESS, DEB, "analysis required\n");
+    XTRACE(PROCESS, DEB, "analysis required");
     analyze();
   }
   old_trigger_timestamp_ns_ = triggerTimestamp_ns;

--- a/prototype2/gdgem/generators/BuilderAPV.cpp
+++ b/prototype2/gdgem/generators/BuilderAPV.cpp
@@ -57,7 +57,7 @@ void BuilderAPV::make_hit(size_t idx) {
   e.strip = data[2] & 0xFFFF;
   e.adc = data[3] & 0xFFFF;
 
-  XTRACE(PROCESS, DEB, "Made hit: %s\n", e.debug().c_str());
+  XTRACE(PROCESS, DEB, "Made hit: %s", e.debug().c_str());
 
   if (dump_csv_)
     vmmsave->tofile("%" PRIu64 ", %u, %u, %u, %u\n", e.time, e.plane_id,

--- a/prototype2/gdgem/nmx/Cluster.cpp
+++ b/prototype2/gdgem/nmx/Cluster.cpp
@@ -99,7 +99,7 @@ void Cluster::analyze(bool weighted, uint16_t max_timebins,
     }
   }
 
-  XTRACE(PROCESS, DEB, "center_sum=%f center_count=%f\n", center_sum,
+  XTRACE(PROCESS, DEB, "center_sum=%f center_count=%f", center_sum,
          center_count);
 
   utpc_center = center_sum / center_count;

--- a/prototype2/gdgem/nmx/Event.cpp
+++ b/prototype2/gdgem/nmx/Event.cpp
@@ -70,7 +70,7 @@ bool Event::time_overlap_thresh(const Cluster& other, double thresh) const
 
 void Event::analyze(bool weighted, int16_t max_timebins,
                     int16_t max_timedif) {
-  XTRACE(PROCESS, DEB, "x.entries.size(): %lu, y.entries.size(): %lu\n",
+  XTRACE(PROCESS, DEB, "x.entries.size(): %lu, y.entries.size(): %lu",
          x.entries.size(), y.entries.size());
   if (x.entries.size()) {
     x.analyze(weighted, max_timebins, max_timedif);

--- a/prototype2/gdgem/vmm2/BuilderVMM2.cpp
+++ b/prototype2/gdgem/vmm2/BuilderVMM2.cpp
@@ -58,7 +58,7 @@ AbstractBuilder::ResultStats BuilderVMM2::process_buffer(char *buf, size_t size)
     XTRACE(PROCESS, DEB,
            "srs/vmm timestamp: srs: 0x%08x, bc: 0x%08x, tdc: 0x%08x\n",
            parser_.srshdr.time, d.bcid, d.tdc);
-    XTRACE(PROCESS, DEB, "srs/vmm chip: %d, channel: %d\n", readout.chip_id, d.chno);
+    XTRACE(PROCESS, DEB, "srs/vmm chip: %d, channel: %d", readout.chip_id, d.chno);
 
     plane = geometry_interpreter_.get_plane(readout);
 
@@ -69,7 +69,7 @@ AbstractBuilder::ResultStats BuilderVMM2::process_buffer(char *buf, size_t size)
         sorter_x.insert(readout);
     } else {
       geom_errors++;
-      XTRACE(PROCESS, DEB, "Bad SRS mapping --  fec: %d, chip: %d\n", readout.fec,
+      XTRACE(PROCESS, DEB, "Bad SRS mapping --  fec: %d, chip: %d", readout.fec,
              readout.chip_id);
     }
 

--- a/prototype2/gdgem/vmm2/BuilderVMM2.h
+++ b/prototype2/gdgem/vmm2/BuilderVMM2.h
@@ -29,7 +29,7 @@ public:
               uint16_t adc_threshold_y, double max_time_gap_y,
               std::string dump_dir, bool dump_csv, bool dump_h5);
 
-  ~BuilderVMM2() { XTRACE(INIT, DEB, "BuilderVMM2 destructor called\n"); }
+  ~BuilderVMM2() { XTRACE(INIT, DEB, "BuilderVMM2 destructor called"); }
 
   /// \todo Martin document
   ResultStats process_buffer(char *buf, size_t size) override;

--- a/prototype2/gdgem/vmm2/EventFormationTest.cpp
+++ b/prototype2/gdgem/vmm2/EventFormationTest.cpp
@@ -62,7 +62,7 @@ TEST_F(EventFormationTest, Initial) {
 
 
     while (!matcher.matched_clusters.empty()) {
-      //XTRACE(PROCESS, DEB, "event_ready()\n");
+      //XTRACE(PROCESS, DEB, "event_ready()");
       event = matcher.matched_clusters.front();
       matcher.matched_clusters.pop_front();
 

--- a/prototype2/gdgem/vmm2/ParserVMM2.cpp
+++ b/prototype2/gdgem/vmm2/ParserVMM2.cpp
@@ -37,7 +37,7 @@ int NMXVMM2SRSData::receive(const char *buffer, int size) {
   error = 0;
 
   if (size < 4) {
-    XTRACE(PROCESS, DEB, "Undersize data\n");
+    XTRACE(PROCESS, DEB, "Undersize data");
     error += size;
     return 0;
   }
@@ -45,12 +45,12 @@ int NMXVMM2SRSData::receive(const char *buffer, int size) {
   struct SRSHdr *srsptr = (struct SRSHdr *)buffer;
   srshdr.fc = ntohl(srsptr->fc);
   if (srshdr.fc == 0xfafafafa) {
-    XTRACE(PROCESS, DEB, "End of Frame\n");
+    XTRACE(PROCESS, DEB, "End of Frame");
     return -1;
   }
 
   if (size < 12) {
-    XTRACE(PROCESS, WAR, "Undersize data II\n");
+    XTRACE(PROCESS, WAR, "Undersize data II");
     error += size;
     return 0;
   }
@@ -64,42 +64,42 @@ int NMXVMM2SRSData::receive(const char *buffer, int size) {
   old_time = srshdr.time;
 
   if (srshdr.dataid == 0x56413200) {
-    XTRACE(PROCESS, DEB, "No Data\n");
+    XTRACE(PROCESS, DEB, "No Data");
     return 0;
   }
 
   if ((srshdr.dataid & 0xffffff00) != 0x564d3200) {
-    XTRACE(PROCESS, WAR, "Unknown data\n");
+    XTRACE(PROCESS, WAR, "Unknown data");
     error += size;
     return 0;
   }
 
   if ((srshdr.fc < old_frame_counter)
       && !frame_counter_overflow(old_frame_counter, srshdr.fc)) {
-    XTRACE(PROCESS, WAR, "Frame counter error\n");
+    XTRACE(PROCESS, WAR, "Frame counter error");
     error++;
   }
   old_frame_counter = srshdr.fc;
 
   if (size < 20) {
-    XTRACE(PROCESS, INF, "No room for data in packet, implicit empty?\n");
+    XTRACE(PROCESS, INF, "No room for data in packet, implicit empty?");
     error += size;
     return 0;
   }
 
   auto datalen = size - 12;
   if ((datalen & 0xfff8) != datalen) {
-    XTRACE(PROCESS, WAR, "Invalid data length: %d\n", datalen);
+    XTRACE(PROCESS, WAR, "Invalid data length: %d", datalen);
     error += size;
     return 0;
   }
 
   int vmmid = srshdr.dataid & 0xff;
-  XTRACE(PROCESS, DEB, "VMM2/3 Data, VMM Id %d\n", vmmid);
+  XTRACE(PROCESS, DEB, "VMM2/3 Data, VMM Id %d", vmmid);
 
   int index = 0;
   while (datalen >= 8) {
-    XTRACE(PROCESS, DEB, "index: %d, datalen %d, elems: %lu\n", index, datalen,
+    XTRACE(PROCESS, DEB, "index: %d, datalen %d, elems: %lu", index, datalen,
            elems);
     uint32_t data1 = htonl(*(uint32_t *)&buffer[12 + 8 * index]);
     uint32_t data2 = htonl(*(uint32_t *)&buffer[16 + 8 * index]);
@@ -111,7 +111,7 @@ int NMXVMM2SRSData::receive(const char *buffer, int size) {
     }
     datalen -= 8;
     if (elems == max_elements && datalen >= 8) {
-      XTRACE(PROCESS, DEB, "Data overflow, skipping %d bytes\n", datalen);
+      XTRACE(PROCESS, DEB, "Data overflow, skipping %d bytes", datalen);
       break;
     }
   }

--- a/prototype2/gdgem/vmm3/BuilderVMM3.cpp
+++ b/prototype2/gdgem/vmm3/BuilderVMM3.cpp
@@ -38,13 +38,13 @@ AbstractBuilder::ResultStats BuilderVMM3::process_buffer(char *buf, size_t size)
 	geom_errors = 0;
 	parser_.receive(buf, size);
 	if (!parser_.stats.hits) {
-		XTRACE(PROCESS, DEB, "NO HITS after parse\n");
+		XTRACE(PROCESS, DEB, "NO HITS after parse");
 		auto & stats = parser_.stats;
 		return AbstractBuilder::ResultStats(stats.hits, stats.errors,
 				geom_errors, stats.lostFrames, stats.badFrames,
 				stats.goodFrames);
 	}
-  XTRACE(PROCESS, DEB, "HITS after parse: %d\n", parser_.stats.hits);
+  XTRACE(PROCESS, DEB, "HITS after parse: %d", parser_.stats.hits);
 
 
 	if (dump_h5_) {
@@ -72,9 +72,9 @@ AbstractBuilder::ResultStats BuilderVMM3::process_buffer(char *buf, size_t size)
 			readout.over_threshold = (d.overThreshold != 0);
 
 			XTRACE(PROCESS, DEB,
-					"srs/vmm timestamp: srs: 0x%08x, bc: 0x%08x, tdc: 0x%08x\n",
+					"srs/vmm timestamp: srs: 0x%08x, bc: 0x%08x, tdc: 0x%08x",
 					readout.srs_timestamp, d.bcid, d.tdc);
-			XTRACE(PROCESS, DEB, "srs/vmm chip: %d, channel: %d\n",
+			XTRACE(PROCESS, DEB, "srs/vmm chip: %d, channel: %d",
 					readout.chip_id, d.chno);
 
 			plane = geometry_interpreter_.get_plane(readout);
@@ -89,7 +89,7 @@ AbstractBuilder::ResultStats BuilderVMM3::process_buffer(char *buf, size_t size)
 			} else {
 				geom_errors++;
 
-				XTRACE(PROCESS, DEB, "Bad SRS mapping --  fec: %d, chip: %d\n",
+				XTRACE(PROCESS, DEB, "Bad SRS mapping --  fec: %d, chip: %d",
 						readout.fec, readout.chip_id);
 			}
 
@@ -107,7 +107,7 @@ AbstractBuilder::ResultStats BuilderVMM3::process_buffer(char *buf, size_t size)
 						readout.over_threshold);
 			}
 		} else {
-			XTRACE(PROCESS, DEB, "No data marker in hit (increment counter?)\n");
+			XTRACE(PROCESS, DEB, "No data marker in hit (increment counter?)");
 		}
 	}
 

--- a/prototype2/gdgem/vmm3/BuilderVMM3.h
+++ b/prototype2/gdgem/vmm3/BuilderVMM3.h
@@ -28,7 +28,7 @@ public:
               uint16_t adc_threshold_y, double max_time_gap_y,
               std::string dump_dir, bool dump_csv, bool dump_h5);
 
-  ~BuilderVMM3() { XTRACE(INIT, DEB, "BuilderVMM2 destructor called\n"); }
+  ~BuilderVMM3() { XTRACE(INIT, DEB, "BuilderVMM2 destructor called"); }
 
   /// \todo Martin document
   ResultStats process_buffer(char *buf, size_t size) override;

--- a/prototype2/gdgem/vmm3/ParserVMM3.cpp
+++ b/prototype2/gdgem/vmm3/ParserVMM3.cpp
@@ -1,6 +1,6 @@
 /** Copyright (C) 2018 European Spallation Source ERIC */
 
-// #include <arpa/inet.h>
+#include <arpa/inet.h>
 #include <cinttypes>
 #include <common/Trace.h>
 #include <cstdio>

--- a/prototype2/gdgem/vmm3/ParserVMM3.cpp
+++ b/prototype2/gdgem/vmm3/ParserVMM3.cpp
@@ -12,12 +12,12 @@
 
 int VMM3SRSData::parse(uint32_t data1, uint16_t data2, struct VMM3Data *vmd) {
 
-	XTRACE(PROCESS, DEB, "data1: 0x%08x, data2: 0x%04x\n", data1, data2);
+	XTRACE(PROCESS, DEB, "data1: 0x%08x, data2: 0x%04x", data1, data2);
 	int dataflag = (data2 >> 15) & 0x1;
 
 	if (dataflag) {
 		/// Data
-		XTRACE(PROCESS, DEB, "SRS Data\n");
+		XTRACE(PROCESS, DEB, "SRS Data");
 
 		vmd->overThreshold = (data2 >> 14) & 0x01;
 		vmd->chno = (data2 >> 8) & 0x3f;
@@ -42,10 +42,10 @@ int VMM3SRSData::parse(uint32_t data1, uint16_t data2, struct VMM3Data *vmd) {
 		uint64_t timestamp_42bit = (timestamp_upper_32bit << 10)
 				+ timestamp_lower_10bit;
 		XTRACE(PROCESS, DEB, "SRS Marker vmmid %d: timestamp lower 10bit %u, timestamp upper 32 bit %u, 42 bit timestamp %" 
-		       PRIu64 "\n",  vmmid, timestamp_lower_10bit, timestamp_upper_32bit,timestamp_42bit);
+		       PRIu64 "",  vmmid, timestamp_lower_10bit, timestamp_upper_32bit,timestamp_42bit);
 		markers[vmmid].fecTimeStamp = timestamp_42bit;
 
-		//XTRACE(PROCESS, DEB, "vmmid: %d\n", vmmid);
+		//XTRACE(PROCESS, DEB, "vmmid: %d", vmmid);
 		return 0;
 	}
 }
@@ -54,7 +54,7 @@ int VMM3SRSData::receive(const char *buffer, int size) {
 	memset(&stats, 0, sizeof(stats));
 
 	if (size < 4) {
-		XTRACE(PROCESS, DEB, "Undersize data\n");
+		XTRACE(PROCESS, DEB, "Undersize data");
 		stats.errors += size;
 		return 0;
 	}
@@ -62,7 +62,7 @@ int VMM3SRSData::receive(const char *buffer, int size) {
 	struct SRSHdr *srsHeaderPtr = (struct SRSHdr *) buffer;
 	srsHeader.frameCounter = ntohl(srsHeaderPtr->frameCounter);
 	if (srsHeader.frameCounter == 0xfafafafa) {
-		//XTRACE(PROCESS, INF, "End of Frame\n");
+		//XTRACE(PROCESS, INF, "End of Frame");
 		stats.badFrames++;
 		//printf("bad frames I: %d\n", stats.bad_frames);
 		stats.errors += size;
@@ -90,7 +90,7 @@ int VMM3SRSData::receive(const char *buffer, int size) {
 	}
 
 	if (size < SRSHeaderSize + HitAndMarkerSize) {
-		XTRACE(PROCESS, WAR, "Undersize data\n");
+		XTRACE(PROCESS, WAR, "Undersize data");
 		stats.badFrames++;
 		stats.errors += size;
 		return 0;
@@ -99,7 +99,7 @@ int VMM3SRSData::receive(const char *buffer, int size) {
 	srsHeader.dataId = ntohl(srsHeaderPtr->dataId);
 	/// maybe add a protocol error counter here
 	if ((srsHeader.dataId & 0xffffff00) != 0x564d3200) {
-		XTRACE(PROCESS, WAR, "Unknown data\n");
+		XTRACE(PROCESS, WAR, "Unknown data");
 		stats.badFrames++;
 		stats.errors += size;
 		return 0;
@@ -112,18 +112,18 @@ int VMM3SRSData::receive(const char *buffer, int size) {
 
 	auto datalen = size - SRSHeaderSize;
 	if ((datalen % 6) != 0) {
-		XTRACE(PROCESS, WAR, "Invalid data length: %d\n", datalen);
+		XTRACE(PROCESS, WAR, "Invalid data length: %d", datalen);
 		stats.badFrames++;
 		stats.errors += size;
 		return 0;
 	}
 
-	// XTRACE(PROCESS, DEB, "VMM3a Data, VMM Id %d\n", vmmid);
+	// XTRACE(PROCESS, DEB, "VMM3a Data, VMM Id %d", vmmid);
 
 	int dataIndex = 0;
 	int readoutIndex = 0;
 	while (datalen >= HitAndMarkerSize) {
-		//XTRACE(PROCESS, DEB, "readoutIndex: %d, datalen %d, elems: %u\n",
+		//XTRACE(PROCESS, DEB, "readoutIndex: %d, datalen %d, elems: %u",
 		//		readoutIndex, datalen, stats.hits);
 		auto Data1Offset = SRSHeaderSize + HitAndMarkerSize * readoutIndex;
 		auto Data2Offset = Data1Offset + Data1Size;
@@ -141,7 +141,7 @@ int VMM3SRSData::receive(const char *buffer, int size) {
 
 		datalen -= 6;
 		if (stats.hits == maxHits && datalen > 0) {
-			XTRACE(PROCESS, INF, "Data overflow, skipping %d bytes\n", datalen);
+			XTRACE(PROCESS, INF, "Data overflow, skipping %d bytes", datalen);
 			stats.errors += datalen;
 			break;
 		}

--- a/prototype2/multiblade/mbcaen.cpp
+++ b/prototype2/multiblade/mbcaen.cpp
@@ -87,7 +87,7 @@ PopulateCLIParser PopulateParser{SetCLIArguments};
 MBCAEN::MBCAEN(BaseSettings settings) : Detector("MBCAEN", settings) {
   Stats.setPrefix("efu.mbcaen");
 
-  XTRACE(INIT, ALW, "Adding stats\n");
+  XTRACE(INIT, ALW, "Adding stats");
   // clang-format off
     Stats.create("input.rx_packets",                mystats.rx_packets);
     Stats.create("input.rx_bytes",                  mystats.rx_bytes);
@@ -108,7 +108,7 @@ MBCAEN::MBCAEN(BaseSettings settings) : Detector("MBCAEN", settings) {
   };
   Detector::AddThreadFunction(processingFunc, "processing");
 
-  XTRACE(INIT, ALW, "Creating %d Multiblade Rx ringbuffers of size %d\n",
+  XTRACE(INIT, ALW, "Creating %d Multiblade Rx ringbuffers of size %d",
          eth_buffer_max_entries, eth_buffer_size);
   eth_ringbuf = new RingBuffer<eth_buffer_size>(eth_buffer_max_entries +
                                                 11); // \todo workaround
@@ -136,7 +136,7 @@ void MBCAEN::input_thread() {
     if ((rdsize = mbdata.receive(eth_ringbuf->getDataBuffer(eth_index),
                                  eth_ringbuf->getMaxBufSize())) > 0) {
       eth_ringbuf->setDataLength(eth_index, rdsize);
-      XTRACE(PROCESS, DEB, "Received an udp packet of length %d bytes\n",
+      XTRACE(PROCESS, DEB, "Received an udp packet of length %d bytes",
              rdsize);
       mystats.rx_packets++;
       mystats.rx_bytes += rdsize;
@@ -150,7 +150,7 @@ void MBCAEN::input_thread() {
 
     // Checking for exit
     if (not runThreads) {
-      XTRACE(INPUT, ALW, "Stopping input thread.\n");
+      XTRACE(INPUT, ALW, "Stopping input thread.");
       return;
     }
   }
@@ -196,7 +196,7 @@ void MBCAEN::processing_thread() {
         mystats.tx_bytes += flatbuffer.produce();
 
         if (not runThreads) {
-          XTRACE(INPUT, ALW, "Stopping processing thread.\n");
+          XTRACE(INPUT, ALW, "Stopping processing thread.");
           return;
         }
 
@@ -222,7 +222,7 @@ void MBCAEN::processing_thread() {
           // \todo fixme remove - is an artifact of mbtext2udp
           if (dp.digi == UINT8_MAX && dp.chan == UINT8_MAX &&
               dp.adc == UINT16_MAX && dp.time == UINT32_MAX) {
-            XTRACE(PROCESS, DEB, "Last point\n");
+            XTRACE(PROCESS, DEB, "Last point");
             builder[0].lastPoint();
             break;
           }
@@ -245,7 +245,7 @@ void MBCAEN::processing_thread() {
             uint32_t pixel_id = essgeom.pixel2D(xcoord, ycoord);
 
             XTRACE(PROCESS, DEB,
-                   "digi: %d, wire: %d, strip: %d, x: %d, y:%d, pixel_id: %d\n",
+                   "digi: %d, wire: %d, strip: %d, x: %d, y:%d, pixel_id: %d",
                    dp.digi, (int)xcoord, (int)ycoord,
                    (int)builder[cassette].getWirePosition(),
                    (int)builder[cassette].getStripPosition(), pixel_id);

--- a/prototype2/multiblade/mbcommon/MultiBladeEventBuilder.cpp
+++ b/prototype2/multiblade/mbcommon/MultiBladeEventBuilder.cpp
@@ -25,7 +25,7 @@ bool multiBladeEventBuilder::addDataPoint(const uint8_t &channel,
                                           const uint16_t &ADC,
                                           const uint32_t &clock) {
 
-  XTRACE(PROCESS, DEB, "Data-point received (%d, %d, %d)\n",
+  XTRACE(PROCESS, DEB, "Data-point received (%d, %d, %d)",
          static_cast<uint>(channel), static_cast<uint>(ADC),
          static_cast<uint>(clock));
 
@@ -33,7 +33,7 @@ bool multiBladeEventBuilder::addDataPoint(const uint8_t &channel,
   m_datapoints_received++;
 
   if (ADC < m_ADC_theshold) {
-    XTRACE(PROCESS, DEB, "ADC-value below threshold. %d < %d\n",
+    XTRACE(PROCESS, DEB, "ADC-value below threshold. %d < %d",
            static_cast<uint>(ADC), static_cast<uint>(m_ADC_theshold));
     return false;
   }
@@ -42,7 +42,7 @@ bool multiBladeEventBuilder::addDataPoint(const uint8_t &channel,
   // strip channels
   if (channel >= m_nwire_channels + m_nstrip_channels) {
     XTRACE(PROCESS, WAR,
-           "Recieved channel number : %d - max channel-number : %d\n",
+           "Recieved channel number : %d - max channel-number : %d",
            static_cast<uint>(channel),
            static_cast<uint>(m_nwire_channels + m_nstrip_channels));
     return false;
@@ -53,7 +53,7 @@ bool multiBladeEventBuilder::addDataPoint(const uint8_t &channel,
     m_cluster_clock = clock;
     m_first_signal = false;
 
-    XTRACE(PROCESS, DEB, "First signal. Setting start clock to : %u\n", clock);
+    XTRACE(PROCESS, DEB, "First signal. Setting start clock to : %u", clock);
   }
 
   // Calculate the number of clock-cycles from the timestamp
@@ -63,7 +63,7 @@ bool multiBladeEventBuilder::addDataPoint(const uint8_t &channel,
   if (clock_diff < m_time_window) {
 
     // point is within time-window
-    XTRACE(PROCESS, DEB, "Within time-window [%u < %u]\n", clock_diff,
+    XTRACE(PROCESS, DEB, "Within time-window [%u < %u]", clock_diff,
            m_time_window);
 
     // Add point to cluster
@@ -73,7 +73,7 @@ bool multiBladeEventBuilder::addDataPoint(const uint8_t &channel,
   }
 
   // point is outside time-window - the cluster is complete.
-  XTRACE(PROCESS, DEB, "Outside time-window [%u > %u]\n", clock_diff,
+  XTRACE(PROCESS, DEB, "Outside time-window [%u > %u]", clock_diff,
          m_time_window);
 
   // multiBladeEventBuilder the stored clusters. True is returned if all checks
@@ -116,14 +116,14 @@ bool multiBladeEventBuilder::processClusters() {
   // Calculate the time-stamp
   m_time_stamp = m_cluster_clock;
 
-  XTRACE(PROCESS, DEB, "Calculated position : Pos(%1.4f, %1.4f)\n", m_wire_pos,
+  XTRACE(PROCESS, DEB, "Calculated position : Pos(%1.4f, %1.4f)", m_wire_pos,
          m_strip_pos);
 
   if ((m_wire_pos < 0) && (m_strip_pos < 0)) {
 
     m_rejected_position++;
 
-    XTRACE(PROCESS, WAR, "Both positions less than 0 - not an event!\n");
+    XTRACE(PROCESS, WAR, "Both positions less than 0 - not an event!");
 
     return false;
   } else {
@@ -145,7 +145,7 @@ bool multiBladeEventBuilder::pointsAdjacent() {
   // Both sets have to be adjacent for a valid cluster
   bool adjacent = wires_adjacent && strips_adjacent;
 
-  XTRACE(PROCESS, DEB, "Wires are%s adjacent, strips are%s adjacent!\n",
+  XTRACE(PROCESS, DEB, "Wires are%s adjacent, strips are%s adjacent!",
          (wires_adjacent ? "" : "not"), (strips_adjacent ? "" : "not"));
 
   return adjacent;
@@ -286,7 +286,7 @@ void multiBladeEventBuilder::incrementCounters(
       m_2D_wires.at(5)++;
 
       XTRACE(PROCESS, DEB,
-             "More points than expected! Number of wire data points = %d\n",
+             "More points than expected! Number of wire data points = %d",
              static_cast<int>(m_wire_cluster.size()));
     }
     if (m_strip_cluster.size() <= 5) {
@@ -295,7 +295,7 @@ void multiBladeEventBuilder::incrementCounters(
       m_2D_strips.at(5)++;
 
       XTRACE(PROCESS, DEB,
-             "More points than expected! Number of strip data points = %d\n",
+             "More points than expected! Number of strip data points = %d",
              static_cast<int>(m_strip_cluster.size()));
     }
   }
@@ -309,7 +309,7 @@ void multiBladeEventBuilder::incrementCounters(
       m_1D_wires.at(5)++;
 
       XTRACE(PROCESS, DEB,
-             "More points than expected! Number of wire data points = %d\n",
+             "More points than expected! Number of wire data points = %d",
              static_cast<int>(m_wire_cluster.size()));
     }
   }
@@ -323,7 +323,7 @@ void multiBladeEventBuilder::incrementCounters(
       m_1D_strips.at(5)++;
 
       XTRACE(PROCESS, DEB,
-             "More points than expected! Number of strip data points = %lu\n",
+             "More points than expected! Number of strip data points = %lu",
              m_strip_cluster.size());
     }
   }

--- a/prototype2/multigrid/CMakeLists.txt
+++ b/prototype2/multigrid/CMakeLists.txt
@@ -56,7 +56,6 @@ set(mgcncsgen_INC
   mgcncs/DataParser.h
   )
 create_executable(mgcncsgen)
-target_link_libraries(mgcncsgen PRIVATE efu_common)
 
 #
 set(mgcncsgenfile_INC generators/DGArgs.h )

--- a/prototype2/multigrid/CMakeLists.txt
+++ b/prototype2/multigrid/CMakeLists.txt
@@ -56,6 +56,7 @@ set(mgcncsgen_INC
   mgcncs/DataParser.h
   )
 create_executable(mgcncsgen)
+target_link_libraries(mgcncsgen PRIVATE efu_common)
 
 #
 set(mgcncsgenfile_INC generators/DGArgs.h )

--- a/prototype2/multigrid/mgcncs/CalibrationFile.cpp
+++ b/prototype2/multigrid/mgcncs/CalibrationFile.cpp
@@ -13,7 +13,7 @@
 
 int CalibrationFile::load(std::string calibration, char *wirecal,
                           char *gridcal) {
-  XTRACE(CMD, INF, "Attempt to load calibration %s\n", calibration.c_str());
+  XTRACE(CMD, INF, "Attempt to load calibration %s", calibration.c_str());
 
   auto file = calibration + std::string(".wcal");
   if (load_file(file, wirecal) < 0) {
@@ -28,7 +28,7 @@ int CalibrationFile::load(std::string calibration, char *wirecal,
 
 int CalibrationFile::save(std::string calibration, char *wirecal,
                           char *gridcal) {
-  XTRACE(CMD, INF, "Attempt to save calibration %s\n", calibration.c_str());
+  XTRACE(CMD, INF, "Attempt to save calibration %s", calibration.c_str());
 
   auto file = calibration + std::string(".wcal");
   if (save_file(file, wirecal) < 0) {
@@ -48,18 +48,18 @@ int CalibrationFile::load_file(std::string file, char *buffer) {
 
   int fd = open(file.c_str(), O_RDONLY);
   if (fd < 0) {
-    XTRACE(CMD, WAR, "file open() failed for %s\n", file.c_str());
+    XTRACE(CMD, WAR, "file open() failed for %s", file.c_str());
     return -10;
   }
 
   if (fstat(fd, &buf) != 0) {
-    XTRACE(CMD, ERR, "fstat() failed for %s\n", file.c_str());
+    XTRACE(CMD, ERR, "fstat() failed for %s", file.c_str());
     close(fd);
     return -11;
   }
 
   if (buf.st_size != CSPECChanConv::adcsize * 2) {
-    XTRACE(CMD, WAR, "file %s has wrong length: %d (should be %d)\n",
+    XTRACE(CMD, WAR, "file %s has wrong length: %d (should be %d)",
            file.c_str(), (int)buf.st_size, 16384 * 2);
     close(fd);
     return -12;
@@ -67,11 +67,11 @@ int CalibrationFile::load_file(std::string file, char *buffer) {
 
   if (read(fd, buffer, CSPECChanConv::adcsize * 2) !=
       CSPECChanConv::adcsize * 2) {
-    XTRACE(CMD, ERR, "read() from %s incomplete\n", file.c_str());
+    XTRACE(CMD, ERR, "read() from %s incomplete", file.c_str());
     close(fd);
     return -13;
   }
-  XTRACE(CMD, INF, "Calibration file %s sucessfully read\n", file.c_str());
+  XTRACE(CMD, INF, "Calibration file %s sucessfully read", file.c_str());
   close(fd);
   return 0;
 }
@@ -83,12 +83,12 @@ int CalibrationFile::save_file(std::string file, char *buffer) {
   int fd;
 
   if ((fd = open(file.c_str(), flags, mode)) < 0) {
-    XTRACE(CMD, ERR, "open() %s failed\n", file.c_str());
+    XTRACE(CMD, ERR, "open() %s failed", file.c_str());
     return -21;
   }
   if (write(fd, buffer, CSPECChanConv::adcsize * 2) !=
       CSPECChanConv::adcsize * 2) {
-    XTRACE(CMD, ERR, "write() to %s incomplete\n", file.c_str());
+    XTRACE(CMD, ERR, "write() to %s incomplete", file.c_str());
     close(fd);
     return -22;
   }

--- a/prototype2/multigrid/mgcncs/ChanConv.cpp
+++ b/prototype2/multigrid/mgcncs/ChanConv.cpp
@@ -47,10 +47,10 @@ int CSPECChanConv::makecal(uint16_t *array, unsigned int min, unsigned int max,
 void CSPECChanConv::load_calibration(uint16_t *wirecal_new,
                                      uint16_t *gridcal_new) {
   if ((wirecal_new == NULL) || (gridcal_new == NULL)) {
-    XTRACE(PROCESS, ERR, "Invalid calibration data\n");
+    XTRACE(PROCESS, ERR, "Invalid calibration data");
     return;
   }
-  XTRACE(PROCESS, INF, "Loading calibration data\n");
+  XTRACE(PROCESS, INF, "Loading calibration data");
   std::memcpy(wirecal, wirecal_new, sizeof(wirecal));
   std::memcpy(gridcal, gridcal_new, sizeof(gridcal));
 }

--- a/prototype2/multigrid/mgcncs/DataParser.cpp
+++ b/prototype2/multigrid/mgcncs/DataParser.cpp
@@ -21,7 +21,7 @@ int CSPECData::createevent(const MultiGridData &data, uint32_t *time,
   auto grid = chanconv->getgridid(data.d[6]);
   auto wire = chanconv->getwireid(data.d[2]);
 
-  XTRACE(PROCESS, DEB, "panel %u, grid %d, wire %d\n", panel, grid, wire);
+  XTRACE(PROCESS, DEB, "panel %u, grid %d, wire %d", panel, grid, wire);
 
   /** \todo eventually get rid of this, but electronics is wrongly wired
    * on the prototype detector currently being tested
@@ -43,12 +43,12 @@ int CSPECData::createevent(const MultiGridData &data, uint32_t *time,
 
   auto pixid = multigridgeom->getdetectorpixelid(panel, grid, wire);
   if (pixid < 1) {
-    XTRACE(PROCESS, WAR, "panel %u, grid %d, wire %d, pixel %d\n", panel, grid,
+    XTRACE(PROCESS, WAR, "panel %u, grid %d, wire %d, pixel %d", panel, grid,
            wire, pixid);
     return -1;
   }
 
-  XTRACE(PROCESS, INF, "panel %u, grid %d, wire %d, pixel %d\n", panel, grid,
+  XTRACE(PROCESS, INF, "panel %u, grid %d, wire %d, pixel %d", panel, grid,
          wire, pixid);
 
   static_assert(sizeof(data.time) == 4, "time should be 32 bit");
@@ -70,17 +70,17 @@ int CSPECData::receive(const char *buffer, int size) {
   int oldsize = size;
 
   while (size >= 4) {
-    // XTRACE(PROCESS, DEB, "elems: %d, size: %d, datap: %p\n", elems, size,
+    // XTRACE(PROCESS, DEB, "elems: %d, size: %d, datap: %p", elems, size,
     // datap);
     switch (state) {
     // Parse Header
     case State::hdr:
       if (((*datap & header_mask) != header_id) ||
           ((*datap & 0xfff) != nwords)) {
-        XTRACE(PROCESS, INF, "State::hdr - header error\n");
+        XTRACE(PROCESS, INF, "State::hdr - header error");
         break;
       }
-      // XTRACE(PROCESS, DEB, "State::hdr valid data, next state State:dat\n");
+      // XTRACE(PROCESS, DEB, "State::hdr valid data, next state State:dat");
       data[elems].module = (*datap >> 16) & 0xff;
       datctr = 0;
       state = State::dat;
@@ -89,28 +89,28 @@ int CSPECData::receive(const char *buffer, int size) {
     // Parse Data
     case State::dat:
       if ((*datap & header_mask) != data_id) {
-        XTRACE(PROCESS, INF, "State::dat - header error\n");
+        XTRACE(PROCESS, INF, "State::dat - header error");
         state = State::hdr;
         break;
       }
       // XTRACE(PROCESS, DEB, "State::dat valid data (%d), next state
-      // State:dat\n",
+      // State:dat",
       //       datctr);
       channel = ((*datap) >> 16) & 0xff;
       // assert(channel == datctr); // asserts for 2016_08_16_0921_sample_ in
       // late 9000s
       if (channel != datctr) {
-        XTRACE(PROCESS, WAR, "State::dat - data order mismatch\n");
+        XTRACE(PROCESS, WAR, "State::dat - data order mismatch");
         state = State::hdr;
         break;
       }
 
       data[elems].d[datctr] = (*datap) & 0x3fff;
-      XTRACE(PROCESS, DEB, "data[%u].d[%u]: %u\n", elems, datctr,
+      XTRACE(PROCESS, DEB, "data[%u].d[%u]: %u", elems, datctr,
              data[elems].d[datctr]);
       datctr++;
       if (datctr == 8) {
-        // XTRACE(PROCESS, DEB, "State:dat all data, next state State:ftr\n");
+        // XTRACE(PROCESS, DEB, "State:dat all data, next state State:ftr");
         state = State::ftr;
       }
       break;
@@ -118,15 +118,15 @@ int CSPECData::receive(const char *buffer, int size) {
     // Parse Footer
     case State::ftr:
       if ((*datap & header_mask) != footer_id) {
-        XTRACE(PROCESS, WAR, "State::ftr - header error\n");
+        XTRACE(PROCESS, WAR, "State::ftr - header error");
         state = State::hdr;
         break;
       }
       // XTRACE(PROCESS, DEB,
-      //       "State::ftr valid data, next state State:hdr, events %u\n",
+      //       "State::ftr valid data, next state State:hdr, events %u",
       //       elems);
       data[elems].time = (*datap) & 0x3fffffff;
-      XTRACE(PROCESS, DEB, "time: %u\n", data[elems].time);
+      XTRACE(PROCESS, DEB, "time: %u", data[elems].time);
       elems++;
       state = State::hdr;
 
@@ -155,7 +155,7 @@ int CSPECData::input_filter() {
   for (unsigned int i = 0; i < elems; i++) {
     data[i].valid = 0;
     if ((data[i].d[0] < wire_thresh) || (data[i].d[4] < grid_thresh)) {
-      XTRACE(PROCESS, INF, "data 0 or 4 failed, thresholds: %u, %u\n",
+      XTRACE(PROCESS, INF, "data 0 or 4 failed, thresholds: %u, %u",
              wire_thresh, grid_thresh);
       discarded++; // due to low signal
       continue;
@@ -163,7 +163,7 @@ int CSPECData::input_filter() {
     data[i].valid = 1;
 
     if (data[i].d[1] >= wire_thresh) {
-      XTRACE(PROCESS, INF, "data 1 or 5 failed, thresholds: %u, %u\n",
+      XTRACE(PROCESS, INF, "data 1 or 5 failed, thresholds: %u, %u",
              wire_thresh, grid_thresh);
       discarded++;       // due to duplicate neutron event
       data[i].valid = 0; // invalidate

--- a/prototype2/multigrid/mgcncs/MultigridGeometry.h
+++ b/prototype2/multigrid/mgcncs/MultigridGeometry.h
@@ -37,12 +37,12 @@ public:
   /// \param gridid Grid ID, calculated from adc values
   /// \param wireid Wire ID , calculated from adc values
   inline int getdetectorpixelid(int panel, int gridid, int wireid) {
-    XTRACE(PROCESS, DEB, "panel %d, gridid %d, wireid %d\n", panel, gridid,
+    XTRACE(PROCESS, DEB, "panel %d, gridid %d, wireid %d", panel, gridid,
            wireid);
 
     if ((panel < 1) || (gridid < 1) || (wireid < 1)) {
       XTRACE(PROCESS, WAR,
-             "undersize geometry: panel %d, gridid %d, wireid %d\n", panel,
+             "undersize geometry: panel %d, gridid %d, wireid %d", panel,
              gridid, wireid);
       return -1;
     }
@@ -50,7 +50,7 @@ public:
     if ((panel > panls_) || (gridid > mods_ * grids_) ||
         (wireid > (mods_ * xwires_ * zwires_))) {
       XTRACE(PROCESS, WAR,
-             "oversize geometry: panel %d, gridid %d, wireid %d\n", panel,
+             "oversize geometry: panel %d, gridid %d, wireid %d", panel,
              gridid, wireid);
       return -1;
     }
@@ -60,23 +60,23 @@ public:
     // printf("column: %d\n", column);
     int gridmin = (column - 1) * grids_ + 1;
     int gridmax = gridmin + grids_ - 1;
-    XTRACE(PROCESS, DEB, "grid: %d, min: %d, max: %d\n", gridid, gridmin,
+    XTRACE(PROCESS, DEB, "grid: %d, min: %d, max: %d", gridid, gridmin,
            gridmax);
     if ((gridid < gridmin) || (gridid > gridmax)) {
-      XTRACE(PROCESS, WAR, "geometry mismatch: wire %d, grid %d\n", wireid,
+      XTRACE(PROCESS, WAR, "geometry mismatch: wire %d, grid %d", wireid,
              gridid);
       return -1;
     }
 
     int panel_offset = mods_ * xwires_ * (panel - 1);
     int x_offset = mods_ * xwires_ - (wireid - 1) / zwires_;
-    XTRACE(PROCESS, DEB, "panel_offset: %d\n", panel_offset);
-    XTRACE(PROCESS, DEB, "x_offset: %d\n", x_offset);
+    XTRACE(PROCESS, DEB, "panel_offset: %d", panel_offset);
+    XTRACE(PROCESS, DEB, "x_offset: %d", x_offset);
     int x = panel_offset + x_offset;
     int y = (gridid - 1) % grids_ + 1;
     int z = (wireid - 1) % zwires_ + 1;
     int pixelid = (x - 1) * grids_ * zwires_ + (y - 1) * zwires_ + z;
-    XTRACE(PROCESS, DEB, "x: %d, y: %d, z: %d (pixel %d)\n", x, y, z, pixelid);
+    XTRACE(PROCESS, DEB, "x: %d, y: %d, z: %d (pixel %d)", x, y, z, pixelid);
 
     return pixelid;
   }

--- a/prototype2/multigrid/mgcncs2.cpp
+++ b/prototype2/multigrid/mgcncs2.cpp
@@ -11,6 +11,7 @@
 #include <common/Producer.h>
 #include <common/RingBuffer.h>
 #include <common/Trace.h>
+#include <common/Log.h>
 #include <efu/Parser.h>
 #include <efu/Server.h>
 #include <multigrid/mgcncs/CalibrationFile.h>
@@ -37,6 +38,11 @@ using namespace memory_sequential_consistent; // Lock free fifo
 
 const int TSC_MHZ = 2900; // Not accurate, do not rely solely on this
 
+/** \todo figure out the right size  of the .._max_entries  */
+static const int eth_buffer_max_entries = 1000;
+static const int eth_buffer_size = 9000;
+static const int kafka_buffer_size = 1000000;
+
 /** ----------------------------------------------------- */
 
 class CSPEC : public Detector {
@@ -44,11 +50,6 @@ public:
   CSPEC(BaseSettings settings);
   void input_thread();
   void processing_thread();
-
-  /** \todo figure out the right size  of the .._max_entries  */
-  static const int eth_buffer_max_entries = 1000;
-  static const int eth_buffer_size = 9000;
-  static const int kafka_buffer_size = 1000000;
 
   int LoadCalib(std::vector<std::string> cmdargs, UNUSED char *output,
                 UNUSED unsigned int *obytes);
@@ -101,10 +102,9 @@ PopulateCLIParser PopulateParser{SetCLIArguments};
 int CSPEC::LoadCalib(std::vector<std::string> cmdargs,
                      __attribute__((unused)) char *output,
                      __attribute__((unused)) unsigned int *obytes) {
-  XTRACE(CMD, INF, "CSPEC_LOAD_CALIB");
-  GLOG_INF("CSPEC_LOAD_CALIB");
+  LOG(Sev::Info, "CSPEC_LOAD_CALIB");
   if (cmdargs.size() != 2) {
-    XTRACE(CMD, WAR, "CSPEC_LOAD_CALIB: wrong number of arguments");
+    LOG(Sev::Warning, "CSPEC_LOAD_CALIB: wrong number of arguments");
     return -Parser::EBADARGS;
   }
   CalibrationFile calibfile;
@@ -122,14 +122,13 @@ int CSPEC::ShowCalib(std::vector<std::string> cmdargs, char *output,
                      unsigned int *obytes) {
   auto nargs = cmdargs.size();
   unsigned int offset = 0;
-  XTRACE(CMD, INF, "CSPEC_SHOW_CALIB");
-  GLOG_INF("CSPEC_SHOW_CALIB");
+  LOG(Sev::Info, "CSPEC_SHOW_CALIB");
   if (nargs == 1) {
     offset = 0;
   } else if (nargs == 2) {
     offset = atoi(cmdargs.at(1).c_str());
   } else {
-    XTRACE(CMD, WAR, "CSPEC_SHOW_CALIB: wrong number of arguments");
+    LOG(Sev::Warning, "CSPEC_SHOW_CALIB: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -147,7 +146,7 @@ int CSPEC::ShowCalib(std::vector<std::string> cmdargs, char *output,
 CSPEC::CSPEC(BaseSettings settings) : Detector("CSPEC Detector (2 thread pipeline)", settings) {
   Stats.setPrefix("efu.cspec2");
 
-  XTRACE(INIT, ALW, "Adding stats");
+  LOG(Sev::Debug, "Adding stats");
   // clang-format off
   Stats.create("input.rx_packets",                mystats.rx_packets);
   Stats.create("input.rx_bytes",                  mystats.rx_bytes);
@@ -181,7 +180,7 @@ CSPEC::CSPEC(BaseSettings settings) : Detector("CSPEC Detector (2 thread pipelin
                        return CSPEC::ShowCalib(cmdargs, output, obytes);
                      });
 
-  XTRACE(INIT, ALW, "Creating %d Ethernet ringbuffers of size %d",
+  LOG(Sev::Debug, "Creating {} Ethernet ringbuffers of size {}",
          eth_buffer_max_entries, eth_buffer_size);
   eth_ringbuf = new RingBuffer<eth_buffer_size>(eth_buffer_max_entries + 11);
 }
@@ -217,7 +216,7 @@ void CSPEC::input_thread() {
 
     // Checking for exit
     if (not runThreads) {
-      XTRACE(INPUT, ALW, "Stopping input thread.");
+      LOG(Sev::Debug, "Stopping input thread.");
       return;
     }
   }
@@ -240,7 +239,7 @@ void CSPEC::processing_thread() {
   while (1) {
     // Check for control from mothership (main)
     if (NewCalibrationData) {
-      XTRACE(PROCESS, INF, "processing_thread loading new calibrations");
+      LOG(Sev::Info, "processing_thread loading new calibrations");
       conv.load_calibration(wirecal, gridcal);
       NewCalibrationData = false;
     }
@@ -285,7 +284,7 @@ void CSPEC::processing_thread() {
 
     // Checking for exit
     if (not runThreads) {
-      XTRACE(INPUT, ALW, "Stopping processing thread.");
+      LOG(Sev::Debug, "Stopping processing thread.");
       return;
     }
   }

--- a/prototype2/multigrid/mgcncs2.cpp
+++ b/prototype2/multigrid/mgcncs2.cpp
@@ -101,10 +101,10 @@ PopulateCLIParser PopulateParser{SetCLIArguments};
 int CSPEC::LoadCalib(std::vector<std::string> cmdargs,
                      __attribute__((unused)) char *output,
                      __attribute__((unused)) unsigned int *obytes) {
-  XTRACE(CMD, INF, "CSPEC_LOAD_CALIB\n");
+  XTRACE(CMD, INF, "CSPEC_LOAD_CALIB");
   GLOG_INF("CSPEC_LOAD_CALIB");
   if (cmdargs.size() != 2) {
-    XTRACE(CMD, WAR, "CSPEC_LOAD_CALIB: wrong number of arguments\n");
+    XTRACE(CMD, WAR, "CSPEC_LOAD_CALIB: wrong number of arguments");
     return -Parser::EBADARGS;
   }
   CalibrationFile calibfile;
@@ -122,14 +122,14 @@ int CSPEC::ShowCalib(std::vector<std::string> cmdargs, char *output,
                      unsigned int *obytes) {
   auto nargs = cmdargs.size();
   unsigned int offset = 0;
-  XTRACE(CMD, INF, "CSPEC_SHOW_CALIB\n");
+  XTRACE(CMD, INF, "CSPEC_SHOW_CALIB");
   GLOG_INF("CSPEC_SHOW_CALIB");
   if (nargs == 1) {
     offset = 0;
   } else if (nargs == 2) {
     offset = atoi(cmdargs.at(1).c_str());
   } else {
-    XTRACE(CMD, WAR, "CSPEC_SHOW_CALIB: wrong number of arguments\n");
+    XTRACE(CMD, WAR, "CSPEC_SHOW_CALIB: wrong number of arguments");
     return -Parser::EBADARGS;
   }
 
@@ -147,7 +147,7 @@ int CSPEC::ShowCalib(std::vector<std::string> cmdargs, char *output,
 CSPEC::CSPEC(BaseSettings settings) : Detector("CSPEC Detector (2 thread pipeline)", settings) {
   Stats.setPrefix("efu.cspec2");
 
-  XTRACE(INIT, ALW, "Adding stats\n");
+  XTRACE(INIT, ALW, "Adding stats");
   // clang-format off
   Stats.create("input.rx_packets",                mystats.rx_packets);
   Stats.create("input.rx_bytes",                  mystats.rx_bytes);
@@ -181,7 +181,7 @@ CSPEC::CSPEC(BaseSettings settings) : Detector("CSPEC Detector (2 thread pipelin
                        return CSPEC::ShowCalib(cmdargs, output, obytes);
                      });
 
-  XTRACE(INIT, ALW, "Creating %d Ethernet ringbuffers of size %d\n",
+  XTRACE(INIT, ALW, "Creating %d Ethernet ringbuffers of size %d",
          eth_buffer_max_entries, eth_buffer_size);
   eth_ringbuf = new RingBuffer<eth_buffer_size>(eth_buffer_max_entries + 11);
 }
@@ -206,7 +206,7 @@ void CSPEC::input_thread() {
       eth_ringbuf->setDataLength(eth_index, rdsize);
       mystats.rx_packets++;
       mystats.rx_bytes += rdsize;
-      XTRACE(INPUT, DEB, "rdsize: %u\n", rdsize);
+      XTRACE(INPUT, DEB, "rdsize: %u", rdsize);
 
       if (input2proc_fifo.push(eth_index) == false) {
         mystats.fifo_push_errors++;
@@ -217,7 +217,7 @@ void CSPEC::input_thread() {
 
     // Checking for exit
     if (not runThreads) {
-      XTRACE(INPUT, ALW, "Stopping input thread.\n");
+      XTRACE(INPUT, ALW, "Stopping input thread.");
       return;
     }
   }
@@ -240,7 +240,7 @@ void CSPEC::processing_thread() {
   while (1) {
     // Check for control from mothership (main)
     if (NewCalibrationData) {
-      XTRACE(PROCESS, INF, "processing_thread loading new calibrations\n");
+      XTRACE(PROCESS, INF, "processing_thread loading new calibrations");
       conv.load_calibration(wirecal, gridcal);
       NewCalibrationData = false;
     }
@@ -285,7 +285,7 @@ void CSPEC::processing_thread() {
 
     // Checking for exit
     if (not runThreads) {
-      XTRACE(INPUT, ALW, "Stopping processing thread.\n");
+      XTRACE(INPUT, ALW, "Stopping processing thread.");
       return;
     }
   }

--- a/prototype2/multigrid/mgmesytec.cpp
+++ b/prototype2/multigrid/mgmesytec.cpp
@@ -97,7 +97,7 @@ private:
 CSPEC::CSPEC(BaseSettings settings) : Detector("CSPEC", settings) {
   Stats.setPrefix("efu.mgmesytec");
 
-  XTRACE(INIT, ALW, "Adding stats\n");
+  XTRACE(INIT, ALW, "Adding stats");
   // clang-format off
   Stats.create("rx_packets",            mystats.rx_packets);
   Stats.create("rx_bytes",              mystats.rx_bytes);
@@ -143,7 +143,7 @@ void CSPEC::mainThread() {
     if ((ReadSize = cspecdata.receive(buffer, eth_buffer_size)) > 0) {
       mystats.rx_packets++;
       mystats.rx_bytes += ReadSize;
-      XTRACE(INPUT, DEB, "read size: %u\n", ReadSize);
+      XTRACE(INPUT, DEB, "read size: %u", ReadSize);
 
       auto res = mesytecdata.parse(buffer, ReadSize, hists, flatbuffer, readouts);
       if (res != MesytecData::error::OK) {
@@ -164,12 +164,12 @@ void CSPEC::mainThread() {
 
       auto entries = readouts.getNumEntries();
       if (entries > 0) {
-        XTRACE(PROCESS, INF, "Flushing readout data for %zu readouts\n", entries);
+        XTRACE(PROCESS, INF, "Flushing readout data for %zu readouts", entries);
         //readouts.produce(); // Periodically produce of readouts
       }
 
       if (!hists.isEmpty()) {
-        XTRACE(PROCESS, INF, "Sending histogram for %zu readouts\n", hists.hit_count());
+        XTRACE(PROCESS, INF, "Sending histogram for %zu readouts", hists.hit_count());
         char *txbuffer;
         auto len = histfb.serialize(hists, &txbuffer);
         monitorprod.produce(txbuffer, len);
@@ -181,7 +181,7 @@ void CSPEC::mainThread() {
 
     // Checking for exit
     if (not runThreads) {
-      XTRACE(INPUT, ALW, "Stopping processing thread.\n");
+      XTRACE(INPUT, ALW, "Stopping processing thread.");
       return;
     }
   }

--- a/prototype2/multigrid/mgmesytec/DataParser.cpp
+++ b/prototype2/multigrid/mgmesytec/DataParser.cpp
@@ -59,7 +59,7 @@ void MesytecData::mesytec_parse_n_words(uint32_t *buffer, int nWords, NMXHists &
       dataWords = *datap & 0x000003ff;
       assert(nWords > dataWords);
       module = (*datap & 0x00ff0000) >> 16;
-      DTRACE(INF, "   trigger %d, data len %d (words), module %d\n", triggers, dataWords, module);
+      DTRACE(INF, "   trigger %d, data len %d (words), module %d", triggers, dataWords, module);
       break;
 
     case mesytecData:
@@ -75,7 +75,7 @@ void MesytecData::mesytec_parse_n_words(uint32_t *buffer, int nWords, NMXHists &
         if (adc > wireadcmax) {
           wiremax = addr;
           wireadcmax = adc;
-          XTRACE(DATA, DEB, "   new wadcmax: ch %d\n", addr);
+          XTRACE(DATA, DEB, "   new wadcmax: ch %d", addr);
         }
         hists.binstrips(addr, adc, 0, 0);
       } else if (mgseq.isGrid(addr) && adc >= gridThresholdLo && adc <= gridThresholdHi) {
@@ -83,41 +83,41 @@ void MesytecData::mesytec_parse_n_words(uint32_t *buffer, int nWords, NMXHists &
         if (adc > gridadcmax) {
           gridmax = addr;
           gridadcmax = adc;
-          XTRACE(DATA, DEB, "   new gadcmax: ch %d\n", addr);
+          XTRACE(DATA, DEB, "   new gadcmax: ch %d", addr);
         }
         hists.binstrips(0,0, addr, adc);
       }
 
       if (accept) {
-        //DTRACE(DEB, "   accepting %d,%d,%d,%d\n", time, bus, addr, adc);
+        //DTRACE(DEB, "   accepting %d,%d,%d,%d", time, bus, addr, adc);
         serializer.addEntry(0, addr, time, adc);
 
         if (dumptofile) {
           mgdata->tofile("%d, %d, %d, %d\n", time, bus, addr, adc);
         }
       } else {
-        //DTRACE(DEB, "   discarding %d,%d,%d,%d\n", time, bus, addr, adc);
+        //DTRACE(DEB, "   discarding %d,%d,%d,%d", time, bus, addr, adc);
         discards++;
       }
       break;
 
     case mesytecTimeOffset:
       bus = (*datap & 0x0f000000) >> 24;
-      DTRACE(INF, "   Timeoffset (bus %d) %d\n", bus, (*datap & 0x0000ffff));
+      DTRACE(INF, "   Timeoffset (bus %d) %d", bus, (*datap & 0x0000ffff));
       break;
 
     default:
       if ((*datap & mesytecTimeStamp) == mesytecTimeStamp) {
-        DTRACE(INF, "   Timestamp: %d\n", *datap & 0x3fffffff);
+        DTRACE(INF, "   Timestamp: %d", *datap & 0x3fffffff);
         break;
       }
 
       if (*datap == 0x00000000) {
-        DTRACE(DEB, "   End of Data\n");
+        DTRACE(DEB, "   End of Data");
         break;
       }
 
-      DTRACE(WAR, "   Unknown: 0x%08x\n", *datap);
+      DTRACE(WAR, "   Unknown: 0x%08x", *datap);
       break;
     }
     wordsleft--;
@@ -125,7 +125,7 @@ void MesytecData::mesytec_parse_n_words(uint32_t *buffer, int nWords, NMXHists &
   }
 
   if (time == -1 || module == -1) {
-    XTRACE(DATA, WAR, "   Warning: time or module not set\n");
+    XTRACE(DATA, WAR, "   Warning: time or module not set");
     readouts = 0;
   }
 }
@@ -152,17 +152,17 @@ MesytecData::error MesytecData::parse(const char *buffer, int size, NMXHists &hi
 
   while (bytesleft > 16) {
     if ((*datap & 0x000000ff) != 0x58) {
-      XTRACE(DATA, WAR, "expeced data value 0x58\n");
+      XTRACE(DATA, WAR, "expeced data value 0x58");
       return error::EUNSUPP;
     }
 
     auto len = ntohs((*datap & 0x00ffff00) >> 8);
-    DTRACE(DEB, "sis3153 datawords %d\n", len);
+    DTRACE(DEB, "sis3153 datawords %d", len);
     datap++;
     bytesleft -= 4;
 
     if ((*datap & 0xff000000) != sisBeginReadout) {
-      XTRACE(DATA, WAR, "expected readout header value 0x%04x, got 0x%04x\n", sisBeginReadout, (*datap & 0xff000000));
+      XTRACE(DATA, WAR, "expected readout header value 0x%04x, got 0x%04x", sisBeginReadout, (*datap & 0xff000000));
       return error::EHEADER;
     }
     datap++;
@@ -172,7 +172,7 @@ MesytecData::error MesytecData::parse(const char *buffer, int size, NMXHists &hi
 
     int pixel = getPixel();
     int time  = getTime();
-    DTRACE(DEB, "Event: time %d, pixel: %d\n", time, pixel);
+    DTRACE(DEB, "Event: time %d, pixel: %d", time, pixel);
     if (pixel != 0) {
       tx_bytes += fbserializer.addevent(time, pixel);
       events++;
@@ -184,7 +184,7 @@ MesytecData::error MesytecData::parse(const char *buffer, int size, NMXHists &hi
     bytesleft -= (len - 3) * 4;
 
     if (*datap != 0x87654321) {
-      XTRACE(DATA, WAR, "Protocol mismatch, expected 0x87654321\n");
+      XTRACE(DATA, WAR, "Protocol mismatch, expected 0x87654321");
       return error::EHEADER;
     }
     datap++;

--- a/prototype2/multigrid/mgmesytec/MG24Detector.h
+++ b/prototype2/multigrid/mgmesytec/MG24Detector.h
@@ -25,7 +25,7 @@ public:
 
   /// \brief select hardware configuration (module) of the detector for correct wire swapping
   void select_module(uint32_t module) {
-    XTRACE(DATA, ALW, "Select detector module: %d\n", module);
+    XTRACE(DATA, ALW, "Select detector module: %d", module);
     module_select = module;
   }
   /// \brief identifies which channels are wires, from drawing by Anton
@@ -37,7 +37,7 @@ public:
   /// \brief return the x coordinate of the detector
   inline int xcoord(int digno, int channel) {
     if (!isWire(channel)) {
-      XTRACE(DATA, WAR, "Getting xcoord() from non wire channel\n");
+      XTRACE(DATA, WAR, "Getting xcoord() from non wire channel");
       return -1;
     }
     /// wire == channel, wires range from 0 - 79
@@ -56,7 +56,7 @@ public:
       channel -= 1;
     }
     if (!isGrid(channel)) {
-      XTRACE(DATA, WAR, "Getting ycoord() from non grid channel\n");
+      XTRACE(DATA, WAR, "Getting ycoord() from non grid channel");
       return -1;
     }
 
@@ -66,7 +66,7 @@ public:
   /// \brief return the z coordinate of the detector
   inline int zcoord(int channel) {
     if (!isWire(channel)) {
-      XTRACE(DATA, WAR, "Getting zcoord() from non wire channel\n");
+      XTRACE(DATA, WAR, "Getting zcoord() from non wire channel");
       return -1;
     }
     if (module_select == 1) {

--- a/prototype2/readout/Readout.cpp
+++ b/prototype2/readout/Readout.cpp
@@ -12,18 +12,18 @@
 int Readout::validate(const char *buffer, uint32_t size) {
   if (buffer == 0) {
     XTRACE(PROCESS, WAR,
-           "no buffer specified\n"); /**< \todo increment counter */
+           "no buffer specified"); /**< \todo increment counter */
     return -Readout::EBUFFER;
   }
 
   if ((size < 64) || (size > 8960)) {
-    XTRACE(PROCESS, WAR, "Invalid data size (%u)\n", size);
+    XTRACE(PROCESS, WAR, "Invalid data size (%u)", size);
     return -Readout::ESIZE;
   }
 
   if (size % 64 != 0) {
     XTRACE(PROCESS, WAR,
-           "data size (%u) is not padded to multiple of 64 bytes\n", size);
+           "data size (%u) is not padded to multiple of 64 bytes", size);
     return -Readout::EPAD;
   }
 
@@ -37,7 +37,7 @@ int Readout::validate(const char *buffer, uint32_t size) {
 
   if (size < sizeof(Readout::Payload) + wordcount * 2U + CKSUMSIZE) {
     XTRACE(PROCESS, WAR,
-           "Data size mismatch: size received %lu, headers and data %d\n",
+           "Data size mismatch: size received %lu, headers and data %d",
            sizeof(Readout::Payload), CKSUMSIZE + wordcount * 2U);
     return -Readout::EHDR;
   }

--- a/prototype2/readout/ReadoutDummy.cpp
+++ b/prototype2/readout/ReadoutDummy.cpp
@@ -12,7 +12,7 @@ int ReadoutDummy::parse(const char *buffer, uint32_t size) {
 
   if (type != detectortype) {
     XTRACE(PROCESS, WAR,
-           "Type idendifier in packet (%u) does not match instrument (%u)\n",
+           "Type idendifier in packet (%u) does not match instrument (%u)",
            type, detectortype);
     return -1;
   }

--- a/prototype2/sonde/Geometry.h
+++ b/prototype2/sonde/Geometry.h
@@ -33,21 +33,21 @@ public:
   inline int getdetectorpixelid(int module, int asch) {
     int asic = asch >> 6;
     if (asic > 3) {
-      XTRACE(PROCESS, WAR, "Invalid asic: %d\n", asic);
+      XTRACE(PROCESS, WAR, "Invalid asic: %d", asic);
       return -1;
     }
     int channel = asch & 0x3f;
     if (channel > 15) {
-      XTRACE(PROCESS, WAR, "Invalid channel: %d\n", channel);
+      XTRACE(PROCESS, WAR, "Invalid channel: %d", channel);
       return -1;
     }
-    XTRACE(PROCESS, DEB, "module %d, asic %d, channel %d\n", module, asic,
+    XTRACE(PROCESS, DEB, "module %d, asic %d, channel %d", module, asic,
            channel);
 
     int x = channel % 4;
     int y = channel / 4;
 
-    XTRACE(PROCESS, DEB, "initial coords x: %d, y %d \n", x, y);
+    XTRACE(PROCESS, DEB, "initial coords x: %d, y %d ", x, y);
 
     if (asic == 0) {
       x = 7 - x;
@@ -60,7 +60,7 @@ public:
     }
 
     int pixelid = essgeometry.pixel2D(x,y);
-    XTRACE(PROCESS, DEB, "coordinates: x %d, y %d, pixel_id: %d\n", x, y,
+    XTRACE(PROCESS, DEB, "coordinates: x %d, y %d, pixel_id: %d", x, y,
            pixelid);
     return pixelid;
   }

--- a/prototype2/sonde/ideas/Data.cpp
+++ b/prototype2/sonde/ideas/Data.cpp
@@ -15,12 +15,12 @@ int IDEASData::parse_buffer(const char *buffer, int size) {
   errors = 0;
 
   if (buffer == nullptr) {
-    XTRACE(PROCESS, WAR, "Invalid buffer\n");
+    XTRACE(PROCESS, WAR, "Invalid buffer");
     return -IDEASData::EBUFFER;
   }
 
   if (size < 11) {
-    XTRACE(PROCESS, WAR, "IDEAS readout header too short (%d bytes)\n", size);
+    XTRACE(PROCESS, WAR, "IDEAS readout header too short (%d bytes)", size);
     return -IDEASData::EBADSIZE;
   }
 
@@ -28,7 +28,7 @@ int IDEASData::parse_buffer(const char *buffer, int size) {
 
   int version = (ntohs(hdr->id) & 0xe000) >> 13;
   if (version != 0) {
-    XTRACE(PROCESS, WAR, "Illegal version number (%d)\n", version);
+    XTRACE(PROCESS, WAR, "Illegal version number (%d)", version);
     return -IDEASData::EHEADER;
   }
   hdr_sysno = (ntohs(hdr->id) & 0x1fff) >> 8;
@@ -45,14 +45,14 @@ int IDEASData::parse_buffer(const char *buffer, int size) {
 
   next_seq_no = (hdr_count + 1) & 0x3fff;
 
-  XTRACE(PROCESS, DEB, "version: %d, sysno: %d, type: 0x%02x\n", version,
+  XTRACE(PROCESS, DEB, "version: %d, sysno: %d, type: 0x%02x", version,
          hdr_sysno, hdr_type);
-  XTRACE(PROCESS, DEB, "sequence flag: %d, packet count: %d\n", hdr_seqflag,
+  XTRACE(PROCESS, DEB, "sequence flag: %d, packet count: %d", hdr_seqflag,
          hdr_count);
-  XTRACE(PROCESS, DEB, "time: 0x%08x, size: 0x%04x\n", hdr_hdrtime, hdr_length);
+  XTRACE(PROCESS, DEB, "time: 0x%08x, size: 0x%04x", hdr_hdrtime, hdr_length);
 
   if (hdr_length + (int)sizeof(struct Header) != size) {
-    XTRACE(PROCESS, WAR, "Packet length mismatch: udp: %d, parsed: %d\n", size,
+    XTRACE(PROCESS, WAR, "Packet length mismatch: udp: %d, parsed: %d", size,
            hdr_length + (int)sizeof(struct Header));
     return -IDEASData::EHEADER;
   }
@@ -60,16 +60,16 @@ int IDEASData::parse_buffer(const char *buffer, int size) {
   auto pktdata = buffer + sizeof(struct Header);
   // auto pktdatasize = size - sizeof(struct Header);
   if (hdr_type == 0xD6) {
-    XTRACE(PROCESS, DEB, "Trigger Time Data Packet\n");
+    XTRACE(PROCESS, DEB, "Trigger Time Data Packet");
     return parse_trigger_time_data_packet(pktdata);
   } else if (hdr_type == 0xD5) {
-    XTRACE(PROCESS, DEB, "Single Event Pulse Height Data Packet\n");
+    XTRACE(PROCESS, DEB, "Single Event Pulse Height Data Packet");
     return parse_single_event_pulse_height_data_packet(pktdata);
   } else if (hdr_type == 0xD4) {
-    XTRACE(PROCESS, DEB, "Multi Event Pulse Height Data Packet\n");
+    XTRACE(PROCESS, DEB, "Multi Event Pulse Height Data Packet");
     return parse_multi_event_pulse_height_data_packet(pktdata);
   } else {
-    XTRACE(PROCESS, WAR, "Unsupported readout format: 0x%02x\n", hdr_type);
+    XTRACE(PROCESS, WAR, "Unsupported readout format: 0x%02x", hdr_type);
     return -IDEASData::EUNSUPP;
   }
 }
@@ -80,11 +80,11 @@ int IDEASData::parse_trigger_time_data_packet(const char *buffer) {
   /**< \todo add check for minimum size */
   uint8_t *datap = (uint8_t *)(buffer);
   int nentries = *datap;
-  XTRACE(PROCESS, DEB, "Number of readout events in packet: %d\n", nentries);
+  XTRACE(PROCESS, DEB, "Number of readout events in packet: %d", nentries);
 
   if (nentries * BYTES_PER_ENTRY + 1 !=
       hdr_length) { /** magic packet numbers, check documentation */
-    XTRACE(PROCESS, WAR, "Data length error: events %d (len %d), got: %d\n",
+    XTRACE(PROCESS, WAR, "Data length error: events %d (len %d), got: %d",
            nentries, nentries * BYTES_PER_ENTRY + 1, hdr_length);
     return -IDEASData::EHEADER;
   }
@@ -103,15 +103,15 @@ int IDEASData::parse_trigger_time_data_packet(const char *buffer) {
         eventdata->tofile("%d, %u, %d, %d, %d\n", hdr_count, hdr_hdrtime,
                          hdr_sysno, asch >> 6, asch & 0x3f);
       }
-      XTRACE(PROCESS, INF, "event: %d, time: 0x%08x, pixel: %d\n", i, time,
+      XTRACE(PROCESS, INF, "event: %d, time: 0x%08x, pixel: %d", i, time,
              data[events].pixel_id);
       events++;
     } else {
-      XTRACE(PROCESS, WAR, "Geometry error in entry %d (asch %d)\n", i, asch);
+      XTRACE(PROCESS, WAR, "Geometry error in entry %d (asch %d)", i, asch);
       errors++;
     }
   }
-  XTRACE(PROCESS, DEB, "Number of events in buffer: %u\n", events);
+  XTRACE(PROCESS, DEB, "Number of events in buffer: %u", events);
   return events;
 }
 
@@ -121,10 +121,10 @@ int IDEASData::parse_single_event_pulse_height_data_packet(const char *buffer) {
   static const int BYTES_PER_ENTRY = 2;
   /** \todo check minimum header length */
   int nentries = ntohs(*(uint16_t *)(buffer + 5));
-  XTRACE(PROCESS, DEB, "Number of readout events in packet: %d\n", nentries);
+  XTRACE(PROCESS, DEB, "Number of readout events in packet: %d", nentries);
 
   if (nentries * BYTES_PER_ENTRY + 7 != hdr_length) {
-    XTRACE(PROCESS, WAR, "Data length error: events %d (len %d), got: %d\n",
+    XTRACE(PROCESS, WAR, "Data length error: events %d (len %d), got: %d",
            nentries, nentries * BYTES_PER_ENTRY + 5, hdr_length);
     return -IDEASData::EHEADER;
   }
@@ -133,7 +133,7 @@ int IDEASData::parse_single_event_pulse_height_data_packet(const char *buffer) {
   int channel = *(uint8_t *)(buffer + 2);
   int hold_delay = ntohs(*(uint16_t *)(buffer + 3));
   XTRACE(PROCESS, DEB,
-         "asic: %d, channel: %d, trigger type: %d, hold delay: %d\n", asic,
+         "asic: %d, channel: %d, trigger type: %d, hold delay: %d", asic,
          channel, trigger_type, hold_delay);
 
   int pixelid = sondegeometry->getdetectorpixelid(hdr_sysno, asic, channel);
@@ -146,7 +146,7 @@ int IDEASData::parse_single_event_pulse_height_data_packet(const char *buffer) {
   for (int i = 0; i < nentries; i++) {
     samples++;
     uint16_t sample = ntohs(*(uint16_t *)(buffer + i * 2 + 7));
-    XTRACE(PROCESS, INF, "sample %3d: 0x%x (%d)\n", i, sample, sample);
+    XTRACE(PROCESS, INF, "sample %3d: 0x%x (%d)", i, sample, sample);
 
     if (dumptofile) {
       sephdata->tofile("%u, %d, %d, %d, %d, %d\n", hdr_hdrtime, trigger_type,
@@ -163,17 +163,17 @@ int IDEASData::parse_single_event_pulse_height_data_packet(const char *buffer) {
 int IDEASData::parse_multi_event_pulse_height_data_packet(const char *buffer) {
   static const int BYTES_PER_SAMPLE = 5;
   if (hdr_length < 12) {
-    XTRACE(PROCESS, WAR, "data packet too short for mpeh data\n");
+    XTRACE(PROCESS, WAR, "data packet too short for mpeh data");
     return -IDEASData::EBADSIZE;
   }
 
   int N = *(uint8_t *)buffer;               /**< number of events            */
   int M = ntohs(*(uint16_t *)(buffer + 1)); /**< number of samples per event */
-  XTRACE(PROCESS, DEB, "Readout events: %d, samples per event %d\n", N, M);
+  XTRACE(PROCESS, DEB, "Readout events: %d, samples per event %d", N, M);
 
   int expect_len = (4 + BYTES_PER_SAMPLE * M) * N + 3;
   if (expect_len > hdr_length) {
-    XTRACE(PROCESS, WAR, "Data length error: expected len %d, got: %d\n",
+    XTRACE(PROCESS, WAR, "Data length error: expected len %d, got: %d",
            expect_len, hdr_length);
     return -IDEASData::EHEADER;
   }
@@ -196,7 +196,7 @@ int IDEASData::parse_multi_event_pulse_height_data_packet(const char *buffer) {
         data[events].pixel_id = static_cast<uint32_t>(pixelid);
         events++;
       }
-      XTRACE(PROCESS, INF, "time %x, tt %d, as %d, ch %d, sampl %x\n", evtime,
+      XTRACE(PROCESS, INF, "time %x, tt %d, as %d, ch %d, sampl %x", evtime,
              trigger_type, asic, channel, sample);
       if (dumptofile) {
         mephdata->tofile("%d, %u, %d, %d, %d, %d\n", hdr_count, evtime,

--- a/prototype2/sonde/ideas/Data.h
+++ b/prototype2/sonde/ideas/Data.h
@@ -15,6 +15,7 @@
 #include <cinttypes>
 #include <common/DataSave.h>
 #include <sonde/Geometry.h>
+#include <memory>
 
 class IDEASData {
 public:

--- a/prototype2/sonde/sonde.cpp
+++ b/prototype2/sonde/sonde.cpp
@@ -89,7 +89,7 @@ PopulateCLIParser PopulateParser{SetCLIArguments};
 SONDEIDEA::SONDEIDEA(BaseSettings settings) : Detector("SoNDe detector using IDEA readout", settings) {
   Stats.setPrefix("efu.sonde");
 
-  XTRACE(INIT, ALW, "Adding stats\n");
+  XTRACE(INIT, ALW, "Adding stats");
   // clang-format off
   Stats.create("input.rx_packets",                mystats.rx_packets);
   Stats.create("input.rx_bytes",                  mystats.rx_bytes);
@@ -109,7 +109,7 @@ SONDEIDEA::SONDEIDEA(BaseSettings settings) : Detector("SoNDe detector using IDE
   };
   Detector::AddThreadFunction(processingFunc, "processing");
 
-  XTRACE(INIT, ALW, "Creating %d SONDE Rx ringbuffers of size %d\n",
+  XTRACE(INIT, ALW, "Creating %d SONDE Rx ringbuffers of size %d",
          eth_buffer_max_entries, eth_buffer_size);
   eth_ringbuf = new RingBuffer<eth_buffer_size>(
       eth_buffer_max_entries + 11); /** \todo testing workaround */
@@ -148,7 +148,7 @@ void SONDEIDEA::input_thread() {
 
     // Checking for exit
     if (not runThreads) {
-      XTRACE(INPUT, ALW, "Stopping input thread.\n");
+      XTRACE(INPUT, ALW, "Stopping input thread.");
       return;
     }
   }
@@ -184,7 +184,7 @@ void SONDEIDEA::processing_thread() {
 
         if (events > 0) {
           for (int i = 0; i < events; i++) {
-            XTRACE(PROCESS, DEB, "flatbuffer.addevent[i: %d](t: %d, pix: %d)\n",
+            XTRACE(PROCESS, DEB, "flatbuffer.addevent[i: %d](t: %d, pix: %d)",
                    i, ideasdata.data[i].time, ideasdata.data[i].pixel_id);
             mystats.tx_bytes += flatbuffer.addevent(ideasdata.data[i].time,
                                                     ideasdata.data[i].pixel_id);
@@ -199,7 +199,7 @@ void SONDEIDEA::processing_thread() {
       }
     }
     if (not runThreads) {
-      XTRACE(INPUT, ALW, "Stopping input thread.\n");
+      XTRACE(INPUT, ALW, "Stopping input thread.");
       return;
     }
   }

--- a/udp/CMakeLists.txt
+++ b/udp/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(udptx
   ${udptx_SRC}
   ${udptx_INC}
   )
-target_link_libraries(udptx eventlib)
+target_link_libraries(udptx eventlib efu_common)
 set_target_properties(udptx PROPERTIES
   COMPILE_FLAGS "-fno-strict-aliasing")
 
@@ -26,7 +26,7 @@ add_executable(udprx
   ${udprx_SRC}
   ${udprx_INC}
   )
-target_link_libraries(udprx eventlib)
+target_link_libraries(udprx eventlib efu_common)
 
 install(TARGETS
   udptx


### PR DESCRIPTION
### Issue reference / description

Things that have been changed/fixed:

* Added support for "real" log messages.
* Set the log message level as a command line argument.
* Write log messages to file.
* Fix linking issues with the plugin system, the plugin now uses the symbols provided by the EFU.
* Changed a bunch of XTRACE calls to LOG-calls.
* Removed the new line ("\n") from __every__ XTRACE call and made it a part of XTRACE.
* Made XTRACE more flexible and slightly safer by switching out macros for C++ code.
* Fixed a few other minor compile, linker and unit test issues.
* Fixed bug in the hardware (MTU) check code.

Note that the new `LOG()` call does not have support for groups. If this is a feature that is used and needed it is easy to add back. The `XTRACE()` call also has support for group masks and the `ALW` (always?) log level, I consider both to be superfluous but I can in principle be convinced to add support for both of these features given a good argument.

I consider the new logging system to be more or less _feature complete_ but I recognise that some of the design choices I made can be discussed. Feel free to comment.

## Checklist for submitter

- [x] Check for conflict with integration test (I do not know how to do this)
- [x] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [x] Recommend for group code review

Also, nominate it on the code_review Slack channel.