### PR TITLE
Fix of crashing bug on exit and not sending graylog messages to graylog server

### DIFF
--- a/prototype2/efu/main.cpp
+++ b/prototype2/efu/main.cpp
@@ -54,7 +54,6 @@ int main(int argc, char *argv[]) {
     Log::AddLogHandler(CI);
     
     Log::SetMinimumSeverity(Severity(efu_args.getLogLevel()));
-    Log::AddLogHandler(new GraylogInterface(GLConfig.address, GLConfig.port));
     if (efu_args.getLogFileName().size() > 0) {
       Log::AddLogHandler(new FileInterface(efu_args.getLogFileName()));
     }
@@ -73,12 +72,15 @@ int main(int argc, char *argv[]) {
     if (EFUArgs::Status::EXIT == efu_args.parseSecondPass(argc, argv)) {
       return 0;
     }
+    GLConfig = efu_args.getGraylogSettings();
+    if (not GLConfig.address.empty()) {
+      Log::AddLogHandler(new GraylogInterface(GLConfig.address, GLConfig.port));
+    }
     efu_args.printSettings();
     DetectorSettings = efu_args.getBaseSettings();
     detector = loader.createDetector(DetectorSettings);
     AffinitySettings = efu_args.getThreadCoreAffinity();
     DetectorName = efu_args.getDetectorName();
-    GLConfig = efu_args.getGraylogSettings();
   }
 
   hwcheck.setMinimumMTU(DetectorSettings.MinimumMTU);


### PR DESCRIPTION
### Issue reference / description

Fixes two issues:
1. Crashing bug on exit in `main()` of the EFU due to use of deallocated (`static`) `std::vector<>`.
2. Initialisation order issue which prevented the graylog logger code from connecting to a server.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
