### PR TITLE
Updated to newer version of CLI11 as there is a bug in older version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ add_custom_target(doxygen
 # Finalize coverage
 #=============================================================================
 set(gcovr_excl_opts
-"--exclude='/.*Test.cpp' --exclude='.*gtest.*.h' --exclude='.*CLI11.hpp'")
+"--exclude='/.*Test.cpp' --exclude='.*gtest.*.h' --exclude='.*CLI.hpp'")
 create_coverage_targets(
   coverage
   runtest

--- a/cmake/modules/FindCLI11.cmake
+++ b/cmake/modules/FindCLI11.cmake
@@ -1,10 +1,10 @@
 find_path(CLI11_ROOT_DIR
-  NAMES include/CLI11.hpp
+  NAMES include/CLI/CLI.hpp
 )
 
 find_path(CLI11_INCLUDE_DIR
-  NAMES CLI11.hpp
-  HINTS ${CLI11_ROOT_DIR}/include
+  NAMES CLI.hpp
+  HINTS ${CLI11_ROOT_DIR}/include/CLI
 )
 
 include(FindPackageHandleStandardArgs)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-cli11/1.4-dm3@ess-dmsc/stable
+cli11/1.6.0@bincrafters/stable
 graylog-logger/1.0.5-dm1@ess-dmsc/stable
 gtest/3121b20-dm3@ess-dmsc/stable
 google-benchmark/4c2af07-dm2@ess-dmsc/stable

--- a/libs/include/BitMath.h
+++ b/libs/include/BitMath.h
@@ -12,7 +12,7 @@
 class BitMath {
 public:
   ///
-  inline static uint32_t reversebits32(register uint32_t x) {
+  inline static uint32_t reversebits32(uint32_t x) {
     x = (((x & 0xaaaaaaaa) >> 1) | ((x & 0x55555555) << 1));
     x = (((x & 0xcccccccc) >> 2) | ((x & 0x33333333) << 2));
     x = (((x & 0xf0f0f0f0) >> 4) | ((x & 0x0f0f0f0f) << 4));
@@ -21,7 +21,7 @@ public:
   }
 
   /// \todo test this
-  inline static uint16_t reversebits16(register uint16_t x) {
+  inline static uint16_t reversebits16(uint16_t x) {
     uint32_t temp = reversebits32(x);
     return (temp >> 16);
   };

--- a/prototype2/adc_readout/AdcSettings.cpp
+++ b/prototype2/adc_readout/AdcSettings.cpp
@@ -23,12 +23,12 @@ void SetCLIArguments(CLI::App &parser, AdcSettings &ReadoutSettings) {
                   "Name of the source of the data as made available on the "
                   "Kafka broker.")
       ->group("ADC Readout Options")
-      ->set_default_val("AdcDemonstrator");
+      ->default_str("AdcDemonstrator");
   parser
       .add_option("--stats_suffix", ReadoutSettings.GrafanaNameSuffix,
                   "Grafana root name suffix, used for the stats.")
       ->group("ADC Readout Options")
-      ->set_default_val("");
+      ->default_str("");
   parser
       .add_flag("--sample_timestamp", ReadoutSettings.SampleTimeStamp,
                 "Provide a timestamp with every single ADC sample. Note: this "
@@ -56,12 +56,12 @@ void SetCLIArguments(CLI::App &parser, AdcSettings &ReadoutSettings) {
                   "Only used when serializing data. Take the mean of # of "
                   "samples (oversample) and serialize that mean.")
       ->group("ADC Readout Options")
-      ->set_default_val("1");
+      ->default_str("1");
   parser
       .add_set("--time_stamp_loc", ReadoutSettings.TimeStampLocation,
                {"Start", "Middle", "End"},
                "Only used when serializing oversampled data. The time stamp "
                "corresponds to one of the following: 'Start', 'Middle', 'End'.")
       ->group("ADC Readout Options")
-      ->set_default_val("Middle");
+      ->default_str("Middle");
 }

--- a/prototype2/adc_readout/AdcSettings.h
+++ b/prototype2/adc_readout/AdcSettings.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <CLI11.hpp>
+#include <CLI/CLI.hpp>
 
 /// \brief ADC readout (and processing) specific settings.
 struct AdcSettings {

--- a/prototype2/common/Detector.h
+++ b/prototype2/common/Detector.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <CLI11.hpp>
+#include <CLI/CLI.hpp>
 #include <atomic>
 #include <common/NewStats.h>
 #include <functional>

--- a/prototype2/common/Detector.h
+++ b/prototype2/common/Detector.h
@@ -23,7 +23,7 @@
 // clang-format off
 struct BaseSettings {
   std::string   DetectorPluginName   = {""};
-  std::string   DetectorAddress      = {""};
+  std::string   DetectorAddress      = {"0.0.0.0"};
   std::uint16_t DetectorPort         = {9000};
   std::uint16_t CommandServerPort    = {8888};
   std::int32_t  ReceiveMaxBytes      = {9000}; // Jumbo frame support

--- a/prototype2/common/EFUArgs.cpp
+++ b/prototype2/common/EFUArgs.cpp
@@ -18,19 +18,19 @@ EFUArgs::EFUArgs() {
   // clang-format off
   CLIParser.set_help_flag(); // Removes the default help flag
   CLIParser.allow_extras(true);
-  CLIParser.allow_ini_extras(true);
+  CLIParser.get_formatter()->column_width(30);
 
   HelpOption = CLIParser.add_flag("-h,--help", "Print this help message and exit")
       ->group("EFU Options")->configurable(false);
 
   CLIParser.add_option("-a,--logip", GraylogConfig.address, "Graylog server IP address")
-      ->group("EFU Options")->set_default_val("127.0.0.1");
+      ->group("EFU Options")->default_str("127.0.0.1");
 
   CLIParser.add_option("-b,--broker_addr", EFUSettings.KafkaBroker, "Kafka broker address")
-      ->group("EFU Options")->set_default_val("localhost");
+      ->group("EFU Options")->default_str("localhost");
 
   CLIParser.add_option("-t,--broker_topic", EFUSettings.KafkaTopic, "Kafka broker topic")
-      ->group("EFU Options")->set_default_val("Detector_data");
+      ->group("EFU Options")->default_str("Detector_data");
 
   CLIParser.add_option("-c,--core_affinity", [this](std::vector<std::string> Input) {
                     return parseAffinityStrings(Input);
@@ -40,13 +40,13 @@ EFUArgs::EFUArgs() {
   CLIParser.add_option("-l,--log_level", [this](std::vector<std::string> Input) {
     return parseLogLevel(Input);
   }, "Set log message level. Set to 1 - 7 or one of \n                              `Critical`, `Error`, `Warning`, `Notice`, `Info`,\n                              or `Debug`. Ex: \"-l Notice\"")
-  ->group("EFU Options")->set_default_val("Info");
+  ->group("EFU Options")->default_str("Info");
   
   CLIParser.add_option("--log_file", LogFileName, "Write log messages to file.")
   ->group("EFU Options");
 
   CLIParser.add_option("-u,--min_mtu", EFUSettings.MinimumMTU, "Minimum value of MTU for all active interfaces")
-      ->group("EFU Options")->set_default_val("9000");
+      ->group("EFU Options")->default_str("9000");
 
   std::string DetectorDescription{"Detector name"};
   std::map<std::string, DetectorModuleSetup> StaticDetModules =
@@ -63,25 +63,25 @@ EFUArgs::EFUArgs() {
 
   CLIParser.add_option("-i,--dip", EFUSettings.DetectorAddress,
                        "IP address of receive interface")
-      ->group("EFU Options")->set_default_val("0.0.0.0");
+      ->group("EFU Options")->default_str("0.0.0.0");
 
   CLIParser.add_option("-p,--port", EFUSettings.DetectorPort, "TCP/UDP receive port")
-      ->group("EFU Options")->set_default_val("9000");
+      ->group("EFU Options")->default_str("9000");
 
   CLIParser.add_option("-m,--cmdport", EFUSettings.CommandServerPort,
                        "Command parser tcp port")
-      ->group("EFU Options")->set_default_val("8888");
+      ->group("EFU Options")->default_str("8888");
 
   CLIParser.add_option("-g,--graphite", EFUSettings.GraphiteAddress,
                        "IP address of graphite metrics server")
-      ->group("EFU Options")->set_default_val("127.0.0.1");
+      ->group("EFU Options")->default_str("127.0.0.1");
 
   CLIParser.add_option("-o,--gport", EFUSettings.GraphitePort, "Graphite tcp port")
-      ->group("EFU Options")->set_default_val("2003");
+      ->group("EFU Options")->default_str("2003");
 
   CLIParser.add_option("-s,--stopafter", EFUSettings.StopAfterSec,
                        "Terminate after timeout seconds")
-      ->group("EFU Options")->set_default_val("4294967295"); // 0xffffffffU
+      ->group("EFU Options")->default_str("4294967295"); // 0xffffffffU
 
   WriteConfigOption = CLIParser
       .add_option("--write_config", ConfigFileName,
@@ -94,15 +94,15 @@ EFUArgs::EFUArgs() {
 
   CLIParser.add_option("--updateinterval", EFUSettings.UpdateIntervalSec,
                        "Stats and event data update interval (seconds).")
-      ->group("EFU Options")->set_default_val("1");
+      ->group("EFU Options")->default_str("1");
 
   CLIParser.add_option("--rxbuffer", EFUSettings.DetectorRxBufferSize,
                        "Receive from detector buffer size.")
-      ->group("EFU Options")->set_default_val("2000000");
+      ->group("EFU Options")->default_str("2000000");
 
   CLIParser.add_option("--txbuffer", EFUSettings.DetectorTxBufferSize,
                   "Transmit to detector buffer size.")
-      ->group("EFU Options")->set_default_val("9216");
+      ->group("EFU Options")->default_str("9216");
   // clang-format on
 }
 
@@ -181,7 +181,7 @@ void EFUArgs::printSettings() {
   // clang-format on
 }
 
-void EFUArgs::printHelp() { std::cout << CLIParser.help(30); }
+void EFUArgs::printHelp() { std::cout << CLIParser.help(); }
 
 EFUArgs::Status EFUArgs::parseFirstPass(const int argc, char *argv[]) {
   try {
@@ -194,9 +194,8 @@ EFUArgs::Status EFUArgs::parseFirstPass(const int argc, char *argv[]) {
     printHelp();
     return Status::EXIT;
   }
-  CLIParser.reset();
+  CLIParser.clear();
   CLIParser.allow_extras(false);
-  CLIParser.allow_ini_extras(false);
   return Status::CONTINUE;
 }
 
@@ -217,7 +216,7 @@ EFUArgs::Status EFUArgs::parseSecondPass(const int argc, char *argv[]) {
       LOG(Sev::Error, "Failed to open config file for writing.");
       return Status::EXIT;
     }
-    ConfigFile << CLIParser.config_to_str(true, "", true);
+    ConfigFile << CLIParser.config_to_str(true, true);
     ConfigFile.close();
     LOG(Sev::Info, "Config file created, now exiting.");
     return Status::EXIT;

--- a/prototype2/common/EFUArgs.h
+++ b/prototype2/common/EFUArgs.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <CLI11.hpp>
+#include <CLI/CLI.hpp>
 #include <common/Detector.h>
 #include <cstdint>
 #include <string>

--- a/prototype2/common/EFUArgsTest.cpp
+++ b/prototype2/common/EFUArgsTest.cpp
@@ -80,12 +80,12 @@ TEST_F(EFUArgsTest, Constructor) {
   auto settings = efu_args.getBaseSettings();
 
   // ASSERT_EQ(12, settings.cpustart); /**< todo fixme */
-  ASSERT_EQ("0.0.0.0", settings.DetectorAddress);
-  ASSERT_EQ(9000, settings.DetectorPort);
-  ASSERT_EQ("localhost", settings.KafkaBroker);
-  ASSERT_EQ("127.0.0.1", settings.GraphiteAddress);
-  ASSERT_EQ(2003, settings.GraphitePort);
-  ASSERT_EQ(0xffffffffU, settings.StopAfterSec);
+  EXPECT_EQ("0.0.0.0", settings.DetectorAddress);
+  EXPECT_EQ(9000, settings.DetectorPort);
+  EXPECT_EQ("localhost:9092", settings.KafkaBroker);
+  EXPECT_EQ("127.0.0.1", settings.GraphiteAddress);
+  EXPECT_EQ(2003, settings.GraphitePort);
+  EXPECT_EQ(0xffffffffU, settings.StopAfterSec);
 }
 
 TEST_F(EFUArgsTest, VerifyCommandLineOptions) {

--- a/prototype2/efu/Loader.h
+++ b/prototype2/efu/Loader.h
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#include <CLI11.hpp>
+#include <CLI/CLI.hpp>
 #include <common/Detector.h>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
### Issue reference / description

Due to the aforementioned bug, the EFU would not compile on latest version of Clang. I also updated the code to use the new function names provided by CLI11 1.6.0. Furthermore, the use of a deprecated (and in C++17 removed) keyword `register` was removed as this also prevented compilation.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.