### PR TITLE
Add docker-based system tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+system-tests

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-system-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG http_proxy
+
+ARG https_proxy
+
+ARG local_conan_server
+
+RUN apt-get update -y && \
+    apt-get --no-install-recommends -y install build-essential git python-pip cmake tzdata vim  && \
+    apt-get -y autoremove && \
+    apt-get clean all && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip==9.0.3 && pip install setuptools && \
+    pip install conan && \
+    rm -rf /root/.cache/pip/*
+
+# Force conan to create .conan directory and profile
+RUN conan profile new default
+
+# Replace the default profile and remotes with the ones from our Ubuntu build node
+ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.json" "/root/.conan/registry.json"
+ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
+
+# Add local Conan server
+RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi
+
+RUN mkdir efu
+
+COPY . efu_src
+RUN cd efu && conan install --build=outdated ../efu_src/conanfile.txt
+
+RUN cd efu && \
+    cmake -DCONAN="MANUAL" ../efu_src && \
+    make -j4

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,11 @@ RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc
 
 RUN mkdir efu
 
-COPY . efu_src
+COPY cmake efu_src/cmake
+COPY libs efu_src/libs
+COPY prototype2 efu_src/prototype2
+COPY utils efu_src/utils
+COPY CMakeLists.txt LICENSE README.md Utilities.cmake conanfile.txt efu_src/
 RUN cd efu && conan install --build=outdated ../efu_src/conanfile.txt
 
 RUN cd efu && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG https_proxy
 ARG local_conan_server
 
 RUN apt-get update -y && \
-    apt-get --no-install-recommends -y install build-essential git python-pip cmake tzdata vim  && \
+    apt-get --no-install-recommends -y install build-essential git python-pip cmake tzdata vim m4 && \
     apt-get -y autoremove && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
@@ -36,3 +36,6 @@ RUN cd efu && conan install --build=outdated ../efu_src/conanfile.txt
 RUN cd efu && \
     cmake -DCONAN="MANUAL" ../efu_src && \
     make -j4
+
+COPY docker_launch.sh /
+CMD ["./docker_launch.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,21 @@ RUN conan profile new default
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.json" "/root/.conan/registry.json"
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
 
-# Add local Conan server
+# Add local Conan server if one is defined in the environment
 RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi
 
+# Do the Conan install step first so that we don't have to rebuild all dependencies if something changes in the efu source
 RUN mkdir efu
+RUN mkdir efu_src
+COPY conanfile.txt efu_src/
+RUN cd efu && conan install --build=outdated ../efu_src/conanfile.txt
 
 COPY cmake efu_src/cmake
 COPY libs efu_src/libs
+COPY utils/udp efu_src/utils/udp
+COPY utils/udpredirect efu_src/utils/udpredirect
 COPY prototype2 efu_src/prototype2
-COPY utils efu_src/utils
-COPY CMakeLists.txt LICENSE README.md Utilities.cmake conanfile.txt efu_src/
-RUN cd efu && conan install --build=outdated ../efu_src/conanfile.txt
+COPY CMakeLists.txt LICENSE README.md Utilities.cmake efu_src/
 
 RUN cd efu && \
     cmake -DCONAN="MANUAL" ../efu_src && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,7 +317,6 @@ def get_system_tests_pipeline() {
                     }  // stage
                     stage("System tests: Archive") {
                         junit "system-tests/SystemTestsOutput.xml"
-                        archiveArtifacts "system-tests/logs/*.log"
                     }
                 }
             } // dir

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -287,6 +287,44 @@ def get_macos_pipeline()
     }
 }
 
+def get_system_tests_pipeline() {
+    return {
+        node('system-test') {
+            cleanWs()
+            dir("${project}") {
+                try{
+                    stage("System tests: Checkout") {
+                        checkout scm
+                    }  // stage
+                    stage("System tests: Install requirements") {
+                        sh """scl enable rh-python35 -- python -m pip install --user --upgrade pip
+                        scl enable rh-python35 -- python -m pip install --user -r system-tests/requirements.txt
+                        """
+                    }  // stage
+                    stage("System tests: Run") {
+                        sh """docker stop \$(docker ps -a -q) && docker rm \$(docker ps -a -q) || true
+                                                """
+			timeout(time: 30, activity: true){
+                            sh """cd system-tests/
+                            scl enable rh-python35 -- python -m pytest -s  --junitxml=./SystemTestsOutput.xml ./
+                            """
+			}
+                    }  // stage
+                }finally {
+		    stage("System tests: Cleanup") {
+                        sh """docker stop \$(docker ps -a -q) && docker rm \$(docker ps -a -q) || true
+                        """
+                    }  // stage
+                    stage("System tests: Archive") {
+                        junit "system-tests/SystemTestsOutput.xml"
+                        archiveArtifacts "system-tests/logs/*.log"
+                    }
+                }
+            } // dir
+        }  // node
+    }  // return
+}  // def
+
 node('docker') {
     dir("${project}_code") {
 
@@ -317,6 +355,9 @@ node('docker') {
         builders[image_key] = get_pipeline(image_key)
     }
     builders['macOS'] = get_macos_pipeline()
+    if ( env.CHANGE_ID ) {
+        builders['system tests'] = get_system_tests_pipeline()
+    }
 
     try {
         parallel builders

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ To run a memory leak test (using Valgrind), run:
 make valgrind
 ```
 
+### [Running System tests (link)](https://github.com/ess-dmsc/event-formation-unit/blob/master/system-tests/README.md)
+
 ## Running the event formation application
 
 En example of the commands required to run an event formation pipeline (in this case the *mbcaen* pipeline) follows:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To run a memory leak test (using Valgrind), run:
 make valgrind
 ```
 
-### [Running System tests (link)](https://github.com/ess-dmsc/event-formation-unit/blob/master/system-tests/README.md)
+### [Running System tests (link)](system-tests/README.md)
 
 ## Running the event formation application
 

--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ "${EXECUTABLE}" = "efu"] || [ -z "${EXECUTABLE}" ]]; then
+  if [[ -z "${CONFIG_FILE}" ] && [ -z "${OPT_ARGS}" ]]; then
+    /efu/bin/efu --help
+  elif [[ -z "${OPT_ARGS}" ]]
+    /efu/bin/efu --read_config=${CONFIG_FILE}
+  else
+    /efu/bin/efu ${OPT_ARGS}
+  fi
+elif [ ! -f /efu/bin/${EXECUTABLE} ]; then
+    echo "Could not find executable with name ${EXECUTABLE}"
+else
+  if [[ -z "${OPT_ARGS}" ]]; then
+    /efu/bin/${EXECUTABLE} --help
+  else
+    /efu/bin/${EXECUTABLE} ${OPT_ARGS}
+  fi
+fi

--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-if [[ "${EXECUTABLE}" = "efu"] || [ -z "${EXECUTABLE}" ]]; then
-  if [[ -z "${CONFIG_FILE}" ] && [ -z "${OPT_ARGS}" ]]; then
+if [ "${EXECUTABLE}" = "efu" ] || [ -z "${EXECUTABLE}" ]; then
+  if [ -z "${CONFIG_FILE}" ] && [ -z "${OPT_ARGS}" ]; then
     /efu/bin/efu --help
-  elif [[ -z "${OPT_ARGS}" ]]
+  elif [ -z "${OPT_ARGS}" ]; then
     /efu/bin/efu --read_config=${CONFIG_FILE}
   else
     /efu/bin/efu ${OPT_ARGS}
@@ -11,7 +11,7 @@ if [[ "${EXECUTABLE}" = "efu"] || [ -z "${EXECUTABLE}" ]]; then
 elif [ ! -f /efu/bin/${EXECUTABLE} ]; then
     echo "Could not find executable with name ${EXECUTABLE}"
 else
-  if [[ -z "${OPT_ARGS}" ]]; then
+  if [ -z "${OPT_ARGS}" ]; then
     /efu/bin/${EXECUTABLE} --help
   else
     /efu/bin/${EXECUTABLE} ${OPT_ARGS}

--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Run specified executable, or the efu by default
+# If a config file or optional arguments are provided then pass
+# them to the executable, otherwise print the help message
+
+# if EXECUTABLE is given as "efu" or omitted, then run the efu
 if [ "${EXECUTABLE}" = "efu" ] || [ -z "${EXECUTABLE}" ]; then
   if [ -z "${CONFIG_FILE}" ] && [ -z "${OPT_ARGS}" ]; then
     /efu/bin/efu --help
@@ -8,8 +13,11 @@ if [ "${EXECUTABLE}" = "efu" ] || [ -z "${EXECUTABLE}" ]; then
   else
     /efu/bin/efu ${OPT_ARGS}
   fi
+  # if specified executable doesn't exist then print an error
 elif [ ! -f /efu/bin/${EXECUTABLE} ]; then
-    echo "Could not find executable with name ${EXECUTABLE}"
+  echo "Could not find executable with name ${EXECUTABLE}"
+  exit 1
+  # if specified executable exists then run it
 else
   if [ -z "${OPT_ARGS}" ]; then
     /efu/bin/${EXECUTABLE} --help

--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -1,0 +1,10 @@
+## event-formation-unit system tests 
+
+### How to run the tests
+
+[optional] Set up a Python virtual environment and activate it (see [here](https://virtualenv.pypa.io/en/stable/))
+* Install Docker 
+
+* Install the requirements using pip: `pip install -r system-tests/requirements.txt`
+
+* Run `pytest -s .` from the `system-tests/` directory

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -7,7 +7,7 @@ import docker
 
 def wait_until_kafka_ready(docker_cmd, docker_options):
     print('Waiting for Kafka broker to be ready for system tests...')
-    conf = {'bootstrap.servers': 'localhost:9092',
+    conf = {'bootstrap.servers': 'localhost:9094',
             'api.version.request': True}
     producer = Producer(**conf)
     kafka_ready = False

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -91,17 +91,6 @@ def build_and_run(options, request):
     request.addfinalizer(fin)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def remove_logs_from_previous_run(request):
-    print("Removing previous log files", flush=True)
-    log_dir_name = os.path.join(os.getcwd(), "logs")
-    dirlist = os.listdir(log_dir_name)
-    for filename in dirlist:
-        if filename.endswith(".log"):
-            os.remove(os.path.join(log_dir_name, filename))
-    print("Removed previous log files", flush=True)
-
-
 @pytest.fixture(scope="module")
 def docker_compose(request):
     """

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -1,0 +1,115 @@
+import os.path
+import pytest
+from compose.cli.main import TopLevelCommand, project_from_options
+from confluent_kafka import Producer
+import docker
+
+
+def wait_until_kafka_ready(docker_cmd, docker_options):
+    print('Waiting for Kafka broker to be ready for system tests...')
+    conf = {'bootstrap.servers': 'localhost:9092',
+            'api.version.request': True}
+    producer = Producer(**conf)
+    kafka_ready = False
+
+    def delivery_callback(err, msg):
+        nonlocal n_polls
+        nonlocal kafka_ready
+        if not err:
+            print('Kafka is ready!')
+            kafka_ready = True
+
+    n_polls = 0
+    while n_polls < 10 and not kafka_ready:
+        producer.produce('waitUntilUp', value='Test message', on_delivery=delivery_callback)
+        producer.poll(10)
+        n_polls += 1
+
+    if not kafka_ready:
+        docker_cmd.down(docker_options)  # Bring down containers cleanly
+        raise Exception('Kafka broker was not ready after 100 seconds, aborting tests.')
+
+
+common_options = {"--no-deps": False,
+                  "--always-recreate-deps": False,
+                  "--scale": "",
+                  "--abort-on-container-exit": False,
+                  "SERVICE": "",
+                  "--remove-orphans": False,
+                  "--no-recreate": True,
+                  "--force-recreate": False,
+                  '--no-build': False,
+                  '--no-color': False,
+                  "--rmi": "none",
+                  "--volumes": True,  # Remove volumes when docker-compose down (don't persist kafka and zk data)
+                  "--follow": False,
+                  "--timestamps": False,
+                  "--tail": "all",
+                  "--detach": True,
+                  "--build": False
+                  }
+
+
+def build_efu_image():
+    client = docker.from_env()
+    print("Building EFU image", flush=True)
+    build_args = {}
+    if "http_proxy" in os.environ:
+        build_args["http_proxy"] = os.environ["http_proxy"]
+    if "https_proxy" in os.environ:
+        build_args["https_proxy"] = os.environ["https_proxy"]
+    image, logs = client.images.build(path="../", tag="event-formation-unit:latest", rm=False, buildargs=build_args)
+    for item in logs:
+        print(item, flush=True)
+
+
+def run_containers(cmd, options):
+    print("Running docker-compose up", flush=True)
+    cmd.up(options)
+    print("\nFinished docker-compose up\n", flush=True)
+    wait_until_kafka_ready(cmd, options)
+
+
+def build_and_run(options, request):
+    build_efu_image()
+    project = project_from_options(os.path.dirname(__file__), options)
+    cmd = TopLevelCommand(project)
+    run_containers(cmd, options)
+
+    def fin():
+        # Stop the containers then remove them and their volumes (--volumes option)
+        print("containers stopping", flush=True)
+        log_options = dict(options)
+        log_options["SERVICE"] = ["efu"]
+        cmd.logs(log_options)
+        options["--timeout"] = 30
+        cmd.down(options)
+        print("containers stopped", flush=True)
+
+    # Using a finalizer rather than yield in the fixture means
+    # that the containers will be brought down even if tests fail
+    request.addfinalizer(fin)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def remove_logs_from_previous_run(request):
+    print("Removing previous log files", flush=True)
+    log_dir_name = os.path.join(os.getcwd(), "logs")
+    dirlist = os.listdir(log_dir_name)
+    for filename in dirlist:
+        if filename.endswith(".log"):
+            os.remove(os.path.join(log_dir_name, filename))
+    print("Removed previous log files", flush=True)
+
+
+@pytest.fixture(scope="module")
+def docker_compose(request):
+    """
+    :type request: _pytest.python.FixtureRequest
+    """
+    print("Started preparing test environment...", flush=True)
+
+    # Options must be given as long form
+    options = common_options
+    options["--file"] = ["docker-compose.yml"]
+    return build_and_run(options, request)

--- a/system-tests/data/MB18Freia.json
+++ b/system-tests/data/MB18Freia.json
@@ -1,0 +1,21 @@
+
+{
+  "Detector": "MB18",
+
+  "InstrumentGeometry": "Freia",
+
+  "DigitizerConfig" : [
+    { "index" : 0, "id" : 137 },
+    { "index" : 1, "id" : 143 },
+    { "index" : 2, "id" : 142 },
+    { "index" : 3, "id" :  31 },
+    { "index" : 4, "id" :  33 },
+    { "index" : 5, "id" :  34 }
+  ],
+
+  "cassettes": 6,
+  "wires": 32,
+  "strips": 32,
+
+  "TimeTickNS": 16
+}

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -16,9 +16,9 @@ services:
       KAFKA_BROKER_ID: 0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    networks:
-      vpcbr:
-        ipv4_address: 10.5.0.4 # Have to specify ip address, udpgen_pcap doesn't like using hostname to publish to
+    #networks:
+    #  vpcbr:
+    #    ipv4_address: 10.5.0.4 # Have to specify ip address, udpgen_pcap doesn't like using hostname to publish to
 
   zookeeper:
     image: zookeeper:3.4

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - efu
     environment:
       EXECUTABLE: udpgen_pcap
-      OPT_ARGS: --filename /ess2_ess_mask.pcap --throttle 200 --ipaddr 10.5.0.5 --port 9000
+      OPT_ARGS: --filename /ess2_ess_mask.pcap --throttle 2000 --ipaddr 10.5.0.5 --port 9000
     volumes:
       - ./data/ess2_ess_mask_truncated.pcap:/ess2_ess_mask.pcap
     networks:

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       KAFKA_BROKER_ID: 0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      vpcbr:
+        ipv4_address: 10.5.0.4 # Have to specify ip address, udpgen_pcap doesn't like using hostname to publish to
 
   zookeeper:
     image: zookeeper:3.4
@@ -27,8 +30,14 @@ services:
     environment:
       EXECUTABLE: efu
       OPT_ARGS: -d /efu/modules/mbcaen.so -f /MB18Freia.json --nohwcheck
+    hostname: efu
     volumes:
       - ./data/MB18Freia.json:/MB18Freia.json
+    ports:
+      - "8889:8888" # So can query efu stats on localhost:8889
+    networks:
+      vpcbr:
+        ipv4_address: 10.5.0.5
 
   efu-udpgen:
     image: event-formation-unit:latest
@@ -36,6 +45,17 @@ services:
       - efu
     environment:
       EXECUTABLE: udpgen_pcap
-      OPT_ARGS: -f /ess2_ess_mask.pcap -t 200
+      OPT_ARGS: --filename /ess2_ess_mask.pcap --throttle 200 --ipaddr 10.5.0.5 --port 9000
     volumes:
       - ./data/ess2_ess_mask_truncated.pcap:/ess2_ess_mask.pcap
+    networks:
+      vpcbr:
+        ipv4_address: 10.5.0.6
+      
+networks:
+  vpcbr:
+    driver: bridge
+    ipam:
+     config:
+       - subnet: 10.5.0.0/16
+         gateway: 10.5.0.1

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -7,21 +7,26 @@ services:
       - zookeeper
     hostname: kafka
     ports:
-      - "9092:9092"
+      - "9094:9094"
+    networks:
+      vpcbr:
+        ipv4_address: 10.5.0.4
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9092,OUTSIDE://localhost:9094
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_MESSAGE_MAX_BYTES: 20000000
       KAFKA_BROKER_ID: 0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    #networks:
-    #  vpcbr:
-    #    ipv4_address: 10.5.0.4 # Have to specify ip address, udpgen_pcap doesn't like using hostname to publish to
 
   zookeeper:
     image: zookeeper:3.4
+    networks:
+      vpcbr:
+        ipv4_address: 10.5.0.3
 
   efu:
     image: event-formation-unit:latest
@@ -29,7 +34,7 @@ services:
       - kafka
     environment:
       EXECUTABLE: efu
-      OPT_ARGS: -d /efu/modules/mbcaen.so -f /MB18Freia.json --nohwcheck
+      OPT_ARGS: -d /efu/modules/mbcaen.so -f /MB18Freia.json -b kafka --nohwcheck
     hostname: efu
     volumes:
       - ./data/MB18Freia.json:/MB18Freia.json
@@ -37,7 +42,7 @@ services:
       - "8889:8888" # So can query efu stats on localhost:8889
     networks:
       vpcbr:
-        ipv4_address: 10.5.0.5
+        ipv4_address: 10.5.0.5 # Have to specify ip address, udpgen_pcap doesn't like using hostname to publish to
 
   efu-udpgen:
     image: event-formation-unit:latest

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '2'
+
+services:
+  kafka:
+    image: wurstmeister/kafka:2.12-2.1.0
+    depends_on:
+      - zookeeper
+    hostname: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_MESSAGE_MAX_BYTES: 20000000
+      KAFKA_BROKER_ID: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  zookeeper:
+    image: zookeeper:3.4
+
+  efu:
+    image: event-formation-unit:latest
+    depends_on:
+      - kafka
+    environment:
+      EXECUTABLE: efu
+      OPT_ARGS: -d /efu/modules/mbcaen.so -f /MB18Freia.json --nohwcheck
+    volumes:
+      - ./data/MB18Freia.json:/MB18Freia.json
+
+  efu-udpgen:
+    image: event-formation-unit:latest
+    depends_on:
+      - efu
+    environment:
+      EXECUTABLE: udpgen_pcap
+      OPT_ARGS: -f /ess2_ess_mask.pcap -t 200
+    volumes:
+      - ./data/ess2_ess_mask_truncated.pcap:/ess2_ess_mask.pcap

--- a/system-tests/requirements.txt
+++ b/system-tests/requirements.txt
@@ -1,0 +1,5 @@
+pytest>=3.4.2
+confluent-kafka==0.11.5
+docker-compose>=1.20.0
+docker>=3.4.1
+h5py>=2.8.0

--- a/system-tests/test_efu.py
+++ b/system-tests/test_efu.py
@@ -6,5 +6,4 @@ from verifymetrics import verify_metric
 
 def test_efu_received_all_sent_udp_packets(docker_compose):
     res, name, op, value, retval = verify_metric("localhost", "8889", "efu.mbcaen.receive.packets:2000")
-    print("Tested metric {}: expected {} {}, got {}".format(name, op, value, retval), flush=True)
-    assert res
+    assert res, "Tested metric {}: expected {} {}, got {}".format(name, op, value, retval)

--- a/system-tests/test_efu.py
+++ b/system-tests/test_efu.py
@@ -2,8 +2,9 @@ import sys
 from os import path
 sys.path.append(path.join(path.dirname(path.dirname(path.abspath(__file__))), "utils", "efushell"))
 from verifymetrics import verify_metric
+from time import sleep
 
 
 def test_efu_received_all_sent_udp_packets(docker_compose):
-    res, name, op, value, retval = verify_metric("localhost", "8889", "efu.mbcaen.receive.packets:2000")
+    res, name, op, value, retval = verify_metric("localhost", 8889, "efu.mbcaen.receive.packets:2000")
     assert res, "Tested metric {}: expected {} {}, got {}".format(name, op, value, retval)

--- a/system-tests/test_efu.py
+++ b/system-tests/test_efu.py
@@ -1,10 +1,10 @@
 import sys
 from os import path
 sys.path.append(path.join(path.dirname(path.dirname(path.abspath(__file__))), "utils", "efushell"))
-from verifymetrics import verify_metrics
+from verifymetrics import verify_metric
 
 
 def test_efu_received_all_sent_udp_packets(docker_compose):
-    for name, op, value, retval in verify_metrics("localhost", "8889", "efu.mbcaen.receive.packets:2000"):
-        print("Validation failed for {}: expected {} {}, got {}".format(name, op, value, retval), flush=True)
-        assert 0
+    res, name, op, value, retval = verify_metric("localhost", "8889", "efu.mbcaen.receive.packets:2000")
+    print("Tested metric {}: expected {} {}, got {}".format(name, op, value, retval), flush=True)
+    assert res

--- a/system-tests/test_efu.py
+++ b/system-tests/test_efu.py
@@ -1,0 +1,10 @@
+import sys
+from os import path
+sys.path.append(path.join(path.dirname(path.dirname(path.abspath(__file__))), "utils", "efushell"))
+from verifymetrics import verify_metrics
+
+
+def test_efu_received_all_sent_udp_packets(docker_compose):
+    for name, op, value, retval in verify_metrics("localhost", "8889", "efu.mbcaen.receive.packets:2000"):
+        print("Validation failed for {}: expected {} {}, got {}".format(name, op, value, retval), flush=True)
+        assert 0

--- a/system-tests/test_efu.py
+++ b/system-tests/test_efu.py
@@ -2,8 +2,10 @@ import sys
 from os import path
 sys.path.append(path.join(path.dirname(path.dirname(path.abspath(__file__))), "utils", "efushell"))
 from verifymetrics import verify_metric
+from time import sleep
 
 
 def test_efu_received_all_sent_udp_packets(docker_compose):
+    sleep(10)  # Wait plenty of time for the EFU to receive and process the event data
     res, name, op, value, retval = verify_metric("localhost", 8889, "efu.mbcaen.receive.packets:2000")
     assert res, "Tested metric {}: expected {} {}, got {}".format(name, op, value, retval)

--- a/system-tests/test_efu.py
+++ b/system-tests/test_efu.py
@@ -2,7 +2,6 @@ import sys
 from os import path
 sys.path.append(path.join(path.dirname(path.dirname(path.abspath(__file__))), "utils", "efushell"))
 from verifymetrics import verify_metric
-from time import sleep
 
 
 def test_efu_received_all_sent_udp_packets(docker_compose):

--- a/utils/efushell/EFUMetrics.py
+++ b/utils/efushell/EFUMetrics.py
@@ -11,7 +11,7 @@ class Metrics:
     def _get_efu_command(self, cmd):
         res = self.driver.Ask(cmd)
 
-        if res.find("Error") != -1:
+        if res.find(b"Error") != -1:
             print("Error getting EFU command")
             sys.exit(1)
         return res
@@ -21,8 +21,8 @@ class Metrics:
 
     def get_all_metrics(self, num_metrics):
         for i in range(1, num_metrics + 1):
-            res =  self._get_efu_command('STAT_GET ' + str(i)).split()
-            name = res[1]
+            res = self._get_efu_command('STAT_GET ' + str(i)).split()
+            name = res[1].decode('utf-8')
             value = int(res[2])
             self.metrics[name] = value
 

--- a/utils/efushell/SocketDriver.py
+++ b/utils/efushell/SocketDriver.py
@@ -26,12 +26,14 @@ class SimpleSocket:
 
     def SendCommand(self, cmd):
         self.access_semaphor.acquire()
-        self.sock.send('{}\n'.format(cmd).encode('utf-8'))
+        cmd += '\n'
+        self.sock.send(cmd.encode('utf-8'))
         self.access_semaphor.release()
 
     def Ask(self, cmd):
         self.access_semaphor.acquire()
-        self.sock.send('{}\n'.format(cmd).encode('utf-8'))
+        cmd += '\n'
+        self.sock.send(cmd.encode('utf-8'))
         reply = self.sock.recv(2048).strip(b'\n')
         self.access_semaphor.release()
         return reply

--- a/utils/efushell/SocketDriver.py
+++ b/utils/efushell/SocketDriver.py
@@ -6,30 +6,32 @@ import threading
 
 
 class SimpleSocket:
-  def __init__(self, hostname = "localhost", port = 8888, timeout = 2):
-    self.access_semaphor = threading.Semaphore(1)
-    try:
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    except socket.error, msg:
-        sys.stderr.write("socket() [Socket connection error] Cannot connect to %s, error: %s\n" % (hostname, msg[0]))
-        sys.exit(1)
+    def __init__(self, hostname="localhost", port=8888, timeout=2):
+        self.access_semaphor = threading.Semaphore(1)
+        try:
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        except socket.error:
+            sys.stderr.write(
+                "socket() [Socket connection error] Cannot connect to %s, error: %s\n" % (hostname, socket.error))
+            sys.exit(1)
 
-    self.sock.settimeout(timeout)
+        self.sock.settimeout(timeout)
 
-    try:
-        self.sock.connect((hostname, port))
-    except socket.error, msg:
-        sys.stderr.write("connect() [Socket connection error] Cannot connect to %s:%d, error: %s\n" % (hostname, port, msg[0]))
-        sys.exit(2)
+        try:
+            self.sock.connect((hostname, port))
+        except socket.error:
+            sys.stderr.write("connect() [Socket connection error] Cannot connect to %s:%d, error: %s\n" % (
+            hostname, port, socket.error))
+            sys.exit(2)
 
-  def SendCommand(self, cmd):
-    self.access_semaphor.acquire()
-    self.sock.send(cmd + '\n')
-    self.access_semaphor.release()
+    def SendCommand(self, cmd):
+        self.access_semaphor.acquire()
+        self.sock.send(cmd + '\n')
+        self.access_semaphor.release()
 
-  def Ask(self, cmd):
-    self.access_semaphor.acquire()
-    self.sock.send(cmd + '\n')
-    reply = self.sock.recv(2048).strip('\n')
-    self.access_semaphor.release()
-    return reply
+    def Ask(self, cmd):
+        self.access_semaphor.acquire()
+        self.sock.send(cmd + '\n')
+        reply = self.sock.recv(2048).strip('\n')
+        self.access_semaphor.release()
+        return reply

--- a/utils/efushell/SocketDriver.py
+++ b/utils/efushell/SocketDriver.py
@@ -26,12 +26,12 @@ class SimpleSocket:
 
     def SendCommand(self, cmd):
         self.access_semaphor.acquire()
-        self.sock.send(cmd + '\n')
+        self.sock.send('{}\n'.format(cmd).encode('utf-8'))
         self.access_semaphor.release()
 
     def Ask(self, cmd):
         self.access_semaphor.acquire()
-        self.sock.send(cmd + '\n')
-        reply = self.sock.recv(2048).strip('\n')
+        self.sock.send('{}\n'.format(cmd).encode('utf-8'))
+        reply = self.sock.recv(2048).strip(b'\n')
         self.access_semaphor.release()
         return reply

--- a/utils/efushell/verifymetrics.py
+++ b/utils/efushell/verifymetrics.py
@@ -3,7 +3,7 @@
 from EFUMetrics import Metrics
 import argparse, sys
 
-def verify_metrics(ip_address, port, test_metrics):
+def verify_metric(ip_address, port, test_metric):
     metrics = Metrics(ip_address, port)
     metrics.get_all_metrics(metrics.get_number_of_stats())
 
@@ -21,8 +21,7 @@ def verify_metrics(ip_address, port, test_metrics):
         retval = metrics.return_metric(name)
         res, op = f(retval, value)
 
-        if res == False:
-            yield name, op, value, retval
+        return res, name, op, value, retval
 
 
 if __name__ == '__main__':
@@ -35,7 +34,9 @@ if __name__ == '__main__':
                         help='grafana metrics to be verified, examples: efu.rx_packets:1234 - strict match. efu.rx_packets:+1234 at least)')
     args = parser.parse_args()
 
-    for name, op, value, retval in verify_metrics(args.i, args.p, args.metrics):
-        print("Validation failed for %s: expected %s %d, got %d" % (name, op, value, retval))
-        sys.exit(1)
+    for test_metric in args.metrics:
+        res, name, op, value, retval = verify_metric(args.i, args.p, test_metric)
+        if not res:
+            print("Validation failed for %s: expected %s %d, got %d" % (name, op, value, retval))
+            sys.exit(1)
     print("OK")

--- a/utils/efushell/verifymetrics.py
+++ b/utils/efushell/verifymetrics.py
@@ -3,20 +3,11 @@
 from EFUMetrics import Metrics
 import argparse, sys
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-i", metavar='ipaddr', help = "server ip address (default 127.0.0.1)",
-                        type = str, default = "127.0.0.1")
-    parser.add_argument("-p", metavar='port', help = "server tcp port (default 8888)",
-                        type = int, default = 8888)
-    parser.add_argument('metrics', metavar='metrics', nargs='+',
-                        help='grafana metrics to be verified, examples: efu.rx_packets:1234 - strict match. efu.rx_packets:+1234 at least)')
-    args = parser.parse_args()
-
-    metrics = Metrics(args.i, args.p)
+def verify_metrics(ip_address, port, test_metrics):
+    metrics = Metrics(ip_address, port)
     metrics.get_all_metrics(metrics.get_number_of_stats())
 
-    for validation in args.metrics:
+    for validation in test_metrics:
         m = validation.split(":")
         if len(m) != 2:
             print("Illegal metric specification: %s (hint use name:value)" % (validation))
@@ -31,6 +22,20 @@ if __name__ == '__main__':
         res, op = f(retval, value)
 
         if res == False:
-            print("Validation failed for %s: expected %s %d, got %d" % (name, op, value, retval))
-            sys.exit(1)
+            yield name, op, value, retval
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", metavar='ipaddr', help = "server ip address (default 127.0.0.1)",
+                        type = str, default = "127.0.0.1")
+    parser.add_argument("-p", metavar='port', help = "server tcp port (default 8888)",
+                        type = int, default = 8888)
+    parser.add_argument('metrics', metavar='metrics', nargs='+',
+                        help='grafana metrics to be verified, examples: efu.rx_packets:1234 - strict match. efu.rx_packets:+1234 at least)')
+    args = parser.parse_args()
+
+    for name, op, value, retval in verify_metrics(args.i, args.p, args.metrics):
+        print("Validation failed for %s: expected %s %d, got %d" % (name, op, value, retval))
+        sys.exit(1)
     print("OK")

--- a/utils/efushell/verifymetrics.py
+++ b/utils/efushell/verifymetrics.py
@@ -3,33 +3,33 @@
 from EFUMetrics import Metrics
 import argparse, sys
 
-def verify_metric(ip_address, port, test_metric):
+
+def verify_metric(ip_address, port, validation):
     metrics = Metrics(ip_address, port)
     metrics.get_all_metrics(metrics.get_number_of_stats())
 
-    for validation in test_metrics:
-        m = validation.split(":")
-        if len(m) != 2:
-            print("Illegal metric specification: %s (hint use name:value)" % (validation))
-            sys.exit(1)
-        name = m[0]
-        value = int(m[1])
-        f = lambda x,y : (x == y, "==")
-        if (m[1])[0] == "+":
-            f = lambda x,y : (x >= y, ">=")
-            value = int(m[1][1:])
-        retval = metrics.return_metric(name)
-        res, op = f(retval, value)
+    m = validation.split(":")
+    if len(m) != 2:
+        print("Illegal metric specification: {} (hint use name:value)".format(validation))
+        sys.exit(1)
+    name = m[0]
+    value = int(m[1])
+    f = lambda x, y: (x == y, "==")
+    if (m[1])[0] == "+":
+        f = lambda x, y: (x >= y, ">=")
+        value = int(m[1][1:])
+    retval = metrics.return_metric(name)
+    res, op = f(retval, value)
 
-        return res, name, op, value, retval
+    return res, name, op, value, retval
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", metavar='ipaddr', help = "server ip address (default 127.0.0.1)",
-                        type = str, default = "127.0.0.1")
-    parser.add_argument("-p", metavar='port', help = "server tcp port (default 8888)",
-                        type = int, default = 8888)
+    parser.add_argument("-i", metavar='ipaddr', help="server ip address (default 127.0.0.1)",
+                        type=str, default="127.0.0.1")
+    parser.add_argument("-p", metavar='port', help="server tcp port (default 8888)",
+                        type=int, default=8888)
     parser.add_argument('metrics', metavar='metrics', nargs='+',
                         help='grafana metrics to be verified, examples: efu.rx_packets:1234 - strict match. efu.rx_packets:+1234 at least)')
     args = parser.parse_args()


### PR DESCRIPTION
#190  / Add docker-based system tests

Closes #190

Instructions for running the tests are included in a markdown file in the `system-tests` directory, which is linked to in the main README.md.

Currently there is only one test, [here](https://github.com/ess-dmsc/event-formation-unit/blob/add_dockerfile/system-tests/test_efu.py), which simply checks that EFU receives the expected number of packets over UDP.

There are some changes to the python scripts in `utils/`. I refactored `verifymetrics.py` so that I could import and use it in the system test. i also made some changes so that the scripts work in Python 3.
**NB** This means we would need to make a small change to the integration test ansible script before merging this PR. If lack of Python 2 support causes you any other problem then I should be able to make the changes work in both versions, but I didn't want to put the effort into that before being sure it is required.

Whilst the system-tests are running, the Kafka broker is exposed on port 9094 of the host machine. It is therefore possible to set a breakpoint in the system test and have a look at what messages have been published by the EFU. For example using [kafkacow](https://github.com/ess-dmsc/kafkacow):
```
kafkacow -C -b localhost:9094 -t FREIA_detector -p 0
```

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
