### PR TITLE
Throw an exception if system test file is not found

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -277,7 +277,7 @@ def get_system_tests_pipeline() {
                                                 """
 			timeout(time: 30, activity: true){
                             sh """cd system-tests/
-                            scl enable rh-python35 -- python -m pytest -s --junitxml=./SystemTestsOutput.xml ./ --pcap-file-path /home/jenkins/data/EFU_reference/multiblade/2018_11_22/wireshark --json-file-path /home/jenkins/data/EFU_reference/multiblade/2018_11_22
+                            scl enable rh-python35 -- python -m pytest -s --junitxml=./SystemTestsOutput.xml ./ --pcap-file-path /home/jenkins/data/EFU_reference/multiblade/2018_11_22/wireshark --json-file-path /home/jenkins/data/EFU_reference/multiblade/2018_11_22/wireshark
                             """
 			}
                     }  // stage

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -6,9 +6,16 @@ import docker
 
 
 def pytest_addoption(parser):
-    parser.addoption("--pcap-file-path", type=str,
+
+    def _is_valid_file(arg, filename):
+        if not os.path.isfile(os.path.join(arg, filename)):
+            raise Exception("The file {} does not exist at the given path {}".format(filename, arg))
+        else:
+            return arg
+
+    parser.addoption("--pcap-file-path", type=lambda x: _is_valid_file(x, "ess2_ess_mask.pcap"),
                      help="Path of directory containing pcap file (ess2_ess_mask.pcap)", required=True)
-    parser.addoption("--json-file-path", type=str,
+    parser.addoption("--json-file-path", type=lambda x: _is_valid_file(x, "MB18Freia.json"),
                      help="Path of directory containing JSON file of detector details (MB18Freia.json)", required=True)
 
 


### PR DESCRIPTION
### Issue reference / description

Closes #204 

Shows a clear error if one of the required files for system tests is not found at the path specified when running pytest:
```
Exception: The file MB18Freia.json does not exist at the given path ./data
```

This is important as we are using files on owncloud which may be moved or removed. Without this change we got the following error instead:
```
efu_1         | terminate called after throwing an instance of 'std::__ios_failure'
efu_1         |   what():  basic_filebuf::underflow error reading the file: iostream error
```

This change can be tested by running the system tests locally with a correct or incorrect path to the test data. Instructions on how to run the tests are here: https://github.com/ess-dmsc/event-formation-unit/blob/master/system-tests/README.md

## Checklist for submitter

- [x] Check for conflict with integration test
- [x] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
