### PR TITLE
Issue 215

### DIFF
--- a/prototype2/common/HistSerializer.cpp
+++ b/prototype2/common/HistSerializer.cpp
@@ -8,8 +8,9 @@
 static_assert(FLATBUFFERS_LITTLEENDIAN,
               "Flatbuffers only tested on little endian systems");
 
-HistSerializer::HistSerializer(size_t buffer_half_size)
-    : builder(2 * buffer_half_size + 256) {}
+HistSerializer::HistSerializer(size_t buffer_half_size, std::string source_name)
+    : builder(2 * buffer_half_size + 256)
+    , SourceName (source_name) {}
 
 
 void HistSerializer::set_callback(ProducerCallback cb) {
@@ -44,8 +45,10 @@ size_t HistSerializer::produce(const Hists &hists) {
   auto dataoff = CreateGEMHist(builder, x_strip_off, y_strip_off, x_adc_off,
                                y_adc_off, clus_adc_off, hists.bin_width());
 
+  auto SourceNameOffset = builder.CreateString(SourceName);
+
   auto msg =
-      CreateMonitorMessage(builder, 0, DataField::GEMHist, dataoff.Union());
+      CreateMonitorMessage(builder, SourceNameOffset, DataField::GEMHist, dataoff.Union());
 
   FinishMonitorMessageBuffer(builder, msg);
 

--- a/prototype2/common/HistSerializer.cpp
+++ b/prototype2/common/HistSerializer.cpp
@@ -47,7 +47,7 @@ size_t HistSerializer::produce(const Hists &hists) {
   auto msg =
       CreateMonitorMessage(builder, 0, DataField::GEMHist, dataoff.Union());
 
-  builder.Finish(msg);
+  FinishMonitorMessageBuffer(builder, msg);
 
   Buffer<uint8_t> buffer(builder.GetBufferPointer(), builder.GetSize());
 

--- a/prototype2/common/HistSerializer.h
+++ b/prototype2/common/HistSerializer.h
@@ -17,7 +17,7 @@
 class HistSerializer {
 public:
   /** \todo document */
-  HistSerializer(size_t buffer_half_size);
+  HistSerializer(size_t buffer_half_size, std::string source_name);
 
   void set_callback(ProducerCallback cb);
 
@@ -28,6 +28,8 @@ private:
   ProducerCallback producer_callback;
 
   flatbuffers::FlatBufferBuilder builder;
+
+  std::string SourceName;
 
   uint8_t *xtrackptr{nullptr};
   uint8_t *ytrackptr{nullptr};

--- a/prototype2/common/HistSerializerTest.cpp
+++ b/prototype2/common/HistSerializerTest.cpp
@@ -57,6 +57,8 @@ TEST_F(HistSerializerTest, DeSerialize) {
     ASSERT_EQ((*xdat)[i], i);
     EXPECT_EQ((*ydat)[i], MAX_STRIP_VAL_TEST - i);
   }
+
+  EXPECT_EQ(std::string(&flatbuffer[4], 4), "mo01");
 }
 
 int main(int argc, char **argv) {

--- a/prototype2/common/HistSerializerTest.cpp
+++ b/prototype2/common/HistSerializerTest.cpp
@@ -31,34 +31,34 @@ public:
 };
 
 TEST_F(HistSerializerTest, Serialize) {
-  HistSerializer histfb(hists.needed_buffer_size());
+  HistSerializer histfb(hists.needed_buffer_size(), "some_source");
   auto len = histfb.produce(hists);
-  ASSERT_TRUE(len >= hists.needed_buffer_size());
+  EXPECT_GE(len, hists.needed_buffer_size());
 }
 
 TEST_F(HistSerializerTest, DeSerialize) {
-  HistSerializer histfb(hists.needed_buffer_size());
+  HistSerializer histfb(hists.needed_buffer_size(), "some_source");
   histfb.set_callback(std::bind(&HistSerializerTest::copy_buffer,
       this, std::placeholders::_1));
 
   histfb.produce(hists);
+  EXPECT_EQ(std::string(&flatbuffer[4], 4), "mo01");
 
   auto monitor = GetMonitorMessage(flatbuffer);
-  auto dtype = monitor->data_type();
-  ASSERT_EQ(dtype, DataField::GEMHist);
+  EXPECT_EQ(monitor->source_name()->str(), "some_source");
+  EXPECT_EQ(monitor->data_type(), DataField::GEMHist);
 
   auto hist = static_cast<const GEMHist *>(monitor->data());
   auto xdat = hist->xstrips();
   auto ydat = hist->ystrips();
-  ASSERT_EQ(xdat->size(), hists.x_strips_hist.size());
-  ASSERT_EQ(ydat->size(), hists.y_strips_hist.size());
+  EXPECT_EQ(xdat->size(), hists.x_strips_hist.size());
+  EXPECT_EQ(ydat->size(), hists.y_strips_hist.size());
 
   for (size_t i = 0; i < hists.x_strips_hist.size(); i++) {
-    ASSERT_EQ((*xdat)[i], i);
+    EXPECT_EQ((*xdat)[i], i);
     EXPECT_EQ((*ydat)[i], MAX_STRIP_VAL_TEST - i);
   }
 
-  EXPECT_EQ(std::string(&flatbuffer[4], 4), "mo01");
 }
 
 int main(int argc, char **argv) {

--- a/prototype2/common/ReadoutSerializer.cpp
+++ b/prototype2/common/ReadoutSerializer.cpp
@@ -34,7 +34,7 @@ size_t ReadoutSerializer::produce() {
 
   auto dataoff = CreateMONHit(builder, planevec, timevec, channelvec, adcvec);
   auto msg = CreateMonitorMessage(builder, 0, DataField::MONHit, dataoff.Union());
-  builder.Finish(msg);
+  FinishMonitorMessageBuffer(builder, msg);
 
   Buffer<uint8_t> buffer(builder.GetBufferPointer(), builder.GetSize());
   if (producer_callback) {

--- a/prototype2/common/ReadoutSerializer.cpp
+++ b/prototype2/common/ReadoutSerializer.cpp
@@ -11,9 +11,9 @@
 static_assert(FLATBUFFERS_LITTLEENDIAN,
               "Flatbuffers only tested on little endian systems");
 
-ReadoutSerializer::ReadoutSerializer(size_t maxarraylength)
-    : maxlen(maxarraylength) {
-      builder.Clear();
+ReadoutSerializer::ReadoutSerializer(size_t maxarraylength, std::string source_name)
+    : maxlen(maxarraylength), SourceName(source_name) {
+  builder.Clear();
 }
 
 void ReadoutSerializer::set_callback(ProducerCallback cb) {
@@ -27,13 +27,17 @@ size_t ReadoutSerializer::produce() {
   if (entries == 0) {
     return 0;
   }
+
+  auto SourceNameOffset = builder.CreateString(SourceName);
+
   auto planevec = builder.CreateVector(planes);
   auto timevec = builder.CreateVector(times);
   auto channelvec = builder.CreateVector(channels);
   auto adcvec = builder.CreateVector(adcs);
 
   auto dataoff = CreateMONHit(builder, planevec, timevec, channelvec, adcvec);
-  auto msg = CreateMonitorMessage(builder, 0, DataField::MONHit, dataoff.Union());
+  auto msg = CreateMonitorMessage(builder, SourceNameOffset,
+                                  DataField::MONHit, dataoff.Union());
   FinishMonitorMessageBuffer(builder, msg);
 
   Buffer<uint8_t> buffer(builder.GetBufferPointer(), builder.GetSize());

--- a/prototype2/common/ReadoutSerializer.h
+++ b/prototype2/common/ReadoutSerializer.h
@@ -17,7 +17,7 @@ class ReadoutSerializer {
 public:
   /// \brief Create the ReadoutSerializer
   /// \param maxentries the number of readout tuples to buffer before sending to Kafka
-  ReadoutSerializer(size_t maxentries);
+  ReadoutSerializer(size_t maxentries, std::string source_name);
 
   void set_callback(ProducerCallback cb);
 
@@ -40,6 +40,8 @@ private:
 
   size_t maxlen{0}; ///< maximum number of entries in array
   flatbuffers::FlatBufferBuilder builder; ///< google flatbuffer builder
+
+  std::string SourceName;
 
   // Will be used to create MONHit
   size_t entries{0}; ///< current number of queues entries

--- a/prototype2/gdgem/GdGemBase.cpp
+++ b/prototype2/gdgem/GdGemBase.cpp
@@ -388,15 +388,15 @@ void GdGemBase::processing_thread() {
   ev42serializer.setProducerCallback(
       std::bind(&Producer::produce2<uint8_t>, &event_producer, std::placeholders::_1));
 
-  Gem::TrackSerializer track_serializer(256, 1);
+  Gem::TrackSerializer track_serializer(256, 1, "nmx_tracks");
   track_serializer.set_callback(
       std::bind(&Producer::produce2<uint8_t>, &monitor_producer, std::placeholders::_1));
 
-  HistSerializer hist_serializer(hists_.needed_buffer_size());
+  HistSerializer hist_serializer(hists_.needed_buffer_size(), "nmx");
   hist_serializer.set_callback(
       std::bind(&Producer::produce2<uint8_t>, &monitor_producer, std::placeholders::_1));
 
-  Gem::TrackSerializer raw_serializer(1500, 1);
+  Gem::TrackSerializer raw_serializer(1500, 1, "nmx_hits");
   raw_serializer.set_callback(
           std::bind(&Producer::produce2<uint8_t>, &hits_producer, std::placeholders::_1));
 

--- a/prototype2/gdgem/nmx/TrackSerializer.cpp
+++ b/prototype2/gdgem/nmx/TrackSerializer.cpp
@@ -75,13 +75,15 @@ Buffer<uint8_t> TrackSerializer::serialize() {
     return Buffer<uint8_t>();
   }
 
+  auto SourceNameOffset = builder.CreateString("dummy_source_name");
+
   auto xtrackvec = builder.CreateVector(xtrack);
   auto ytrackvec = builder.CreateVector(ytrack);
   auto dataoff =
       CreateGEMTrack(builder, time_offset, xtrackvec, ytrackvec, xpos, ypos);
   auto msg =
-      CreateMonitorMessage(builder, 0, DataField::GEMTrack, dataoff.Union());
-  builder.Finish(msg);
+      CreateMonitorMessage(builder, SourceNameOffset, DataField::GEMTrack, dataoff.Union());
+  FinishMonitorMessageBuffer(builder, msg);
   xtrack.clear();
   ytrack.clear();
   Buffer<uint8_t> ret(builder.GetBufferPointer(), builder.GetSize());

--- a/prototype2/gdgem/nmx/TrackSerializer.cpp
+++ b/prototype2/gdgem/nmx/TrackSerializer.cpp
@@ -24,10 +24,11 @@ static_assert(FLATBUFFERS_LITTLEENDIAN,
 
 namespace Gem {
 
-TrackSerializer::TrackSerializer(size_t maxarraylength, double target_res)
+TrackSerializer::TrackSerializer(size_t maxarraylength, double target_res, std::string source_name)
     : maxlen(maxarraylength)
     , builder(maxlen * EV_SIZE * 2 + BUF_STATIC_SIZE + 256)
-    , target_resolution_(target_res) {
+    , target_resolution_(target_res)
+    , SourceName (source_name) {
   builder.Clear();
 }
 
@@ -75,7 +76,7 @@ Buffer<uint8_t> TrackSerializer::serialize() {
     return Buffer<uint8_t>();
   }
 
-  auto SourceNameOffset = builder.CreateString("dummy_source_name");
+  auto SourceNameOffset = builder.CreateString(SourceName);
 
   auto xtrackvec = builder.CreateVector(xtrack);
   auto ytrackvec = builder.CreateVector(ytrack);

--- a/prototype2/gdgem/nmx/TrackSerializer.h
+++ b/prototype2/gdgem/nmx/TrackSerializer.h
@@ -19,7 +19,7 @@ namespace Gem {
 class TrackSerializer {
 public:
   /// \todo document
-  TrackSerializer(size_t maxarraylength, double target_res);
+  TrackSerializer(size_t maxarraylength, double target_res, std::string source_name);
 
   void set_callback(ProducerCallback cb);
 
@@ -34,6 +34,8 @@ private:
   size_t maxlen{0};
   flatbuffers::FlatBufferBuilder builder;
   double target_resolution_{1};
+
+  std::string SourceName;
 
   ProducerCallback producer_callback;
 

--- a/prototype2/gdgem/nmx/TrackSerializerTest.cpp
+++ b/prototype2/gdgem/nmx/TrackSerializerTest.cpp
@@ -32,7 +32,7 @@ protected:
 };
 
 TEST_F(TrackSerializerTest, Constructor) {
-  TrackSerializer tser(2560, 1);
+  TrackSerializer tser(2560, 1, "some_source");
   auto buffer = tser.serialize();
   EXPECT_EQ(buffer.size, 0);
   EXPECT_EQ(buffer.address, nullptr);
@@ -40,7 +40,7 @@ TEST_F(TrackSerializerTest, Constructor) {
 
 TEST_F(TrackSerializerTest, AddTrackTooManyHits) {
   int entries = NB_ENTRIES;
-  TrackSerializer tser(entries, 1);
+  TrackSerializer tser(entries, 1, "some_source");
   for (int i = 0; i < entries + 1; i++) {
     addxandy(i, 2 * i, 500, i - 1, 3 * i - 1, 500);
   }
@@ -49,7 +49,7 @@ TEST_F(TrackSerializerTest, AddTrackTooManyHits) {
 
 TEST_F(TrackSerializerTest, Serialize) {
   unsigned int entries = NB_ENTRIES;
-  TrackSerializer tser(entries, 1);
+  TrackSerializer tser(entries, 1, "some_source");
   for (unsigned int i = 0; i < entries; i++) {
     addxandy(i, 2 * i, 500, i - 1, 3 * i - 1, 500);
   }
@@ -68,7 +68,7 @@ TEST_F(TrackSerializerTest, DeSerialize) {
   unsigned int entries = NB_ENTRIES;
   unsigned int entry_size = 4 * 3; // Three uint32_t's
 
-  TrackSerializer tser(entries, 1);
+  TrackSerializer tser(entries, 1, "some_source");
   for (unsigned int i = 0; i < entries; i++) {
     addxandy(i, 0x1111, 0x2222, 100 + i, 0x3333, 0x4444);
   }
@@ -86,8 +86,8 @@ TEST_F(TrackSerializerTest, DeSerialize) {
   memcpy(flatbuffer, buffer.address, buffer.size);
 
   auto monitor = GetMonitorMessage(flatbuffer);
-  auto dtype = monitor->data_type();
-  EXPECT_EQ(dtype, DataField::GEMTrack);
+  EXPECT_EQ(monitor->source_name()->str(), "some_source");
+  EXPECT_EQ(monitor->data_type(), DataField::GEMTrack);
 
   auto track = static_cast<const GEMTrack *>(monitor->data());
   auto xdat = track->xtrack();
@@ -110,7 +110,7 @@ TEST_F(TrackSerializerTest, Validate1000IncreasingSize) {
     EXPECT_FALSE(event.c1.hits.size());
     EXPECT_FALSE(event.c2.hits.size());
 
-    TrackSerializer tser(entries, 1);
+    TrackSerializer tser(entries, 1, "some_source");
     for (unsigned int i = 0; i < entries; i++) {
       addxandy(i, i * 2, i * 3 + 1, entries - i, i * 2 + 0x1000,
                i * 3 + 0x2000);
@@ -129,8 +129,8 @@ TEST_F(TrackSerializerTest, Validate1000IncreasingSize) {
     memcpy(flatbuffer, buffer.address, buffer.size);
 
     auto monitor = GetMonitorMessage(flatbuffer);
-    auto dtype = monitor->data_type();
-    EXPECT_EQ(dtype, DataField::GEMTrack);
+    EXPECT_EQ(monitor->source_name()->str(), "some_source");
+    EXPECT_EQ(monitor->data_type(), DataField::GEMTrack);
 
     auto track = static_cast<const GEMTrack *>(monitor->data());
     auto xdat = track->xtrack();
@@ -156,7 +156,7 @@ TEST_F(TrackSerializerTest, Validate1000SameSize) {
   unsigned int entries = 256;
   unsigned int entry_size = 4 * 3; // Three uint32_t's
   MESSAGE() << "Reusing the same TrackSerializer object\n";
-  TrackSerializer tser(entries, 1);
+  TrackSerializer tser(entries, 1, "some_source");
   for (unsigned int i = 1; i <= 1000; i *= 2) {
     event.c1.hits.clear();
     event.c2.hits.clear();
@@ -176,8 +176,8 @@ TEST_F(TrackSerializerTest, Validate1000SameSize) {
     memcpy(flatbuffer, buffer.address, buffer.size);
 
     auto monitor = GetMonitorMessage(flatbuffer);
-    auto dtype = monitor->data_type();
-    EXPECT_EQ(dtype, DataField::GEMTrack);
+    EXPECT_EQ(monitor->source_name()->str(), "some_source");
+    EXPECT_EQ(monitor->data_type(), DataField::GEMTrack);
 
     auto track = static_cast<const GEMTrack *>(monitor->data());
     auto xdat = track->xtrack();

--- a/prototype2/gdgem/nmx/TrackSerializerTest.cpp
+++ b/prototype2/gdgem/nmx/TrackSerializerTest.cpp
@@ -59,6 +59,9 @@ TEST_F(TrackSerializerTest, Serialize) {
   EXPECT_TRUE(buffer.size <
               entries * 2 * 12 + BASE_OVERHEAD + entries * ENTRY_OVERHEAD);
   EXPECT_NE(buffer.address, nullptr);
+
+  // Ensure header is there
+  EXPECT_EQ(std::string(reinterpret_cast<const char*>(&buffer[4]), 4), "mo01");
 }
 
 TEST_F(TrackSerializerTest, DeSerialize) {
@@ -91,6 +94,9 @@ TEST_F(TrackSerializerTest, DeSerialize) {
   auto ydat = track->ytrack();
   EXPECT_EQ(xdat->size(), entries);
   EXPECT_EQ(ydat->size(), entries);
+
+  // Ensure header is there
+  EXPECT_EQ(std::string(reinterpret_cast<const char*>(&buffer[4]), 4), "mo01");
 }
 
 TEST_F(TrackSerializerTest, Validate1000IncreasingSize) {
@@ -140,6 +146,9 @@ TEST_F(TrackSerializerTest, Validate1000IncreasingSize) {
       EXPECT_EQ((*ydat)[i]->time(), i * 2 + 0x1000);
       EXPECT_EQ((*ydat)[i]->adc(), i * 3 + 0x2000);
     }
+
+    // Ensure header is there
+    EXPECT_EQ(std::string(&flatbuffer[4], 4), "mo01");
   }
 }
 
@@ -184,6 +193,9 @@ TEST_F(TrackSerializerTest, Validate1000SameSize) {
       EXPECT_EQ((*ydat)[k]->time(), k * 2 + 0x1000);
       EXPECT_EQ((*ydat)[k]->adc(), k * 3 + 0x2000);
     }
+
+    // Ensure header is there
+    EXPECT_EQ(std::string(&flatbuffer[4], 4), "mo01");
   }
 }
 

--- a/prototype2/multiblade/MBCaenBase.cpp
+++ b/prototype2/multiblade/MBCaenBase.cpp
@@ -186,7 +186,7 @@ void CAENBase::processing_thread() {
 
   Hists histograms(std::max(ncass * nwires, ncass * nstrips), 65535);
   Producer monitorprod(EFUSettings.KafkaBroker, monitor);
-  HistSerializer histfb(histograms.needed_buffer_size());
+  HistSerializer histfb(histograms.needed_buffer_size(), "multiblade");
   histfb.set_callback(
       std::bind(&Producer::produce2<uint8_t>, &monitorprod, std::placeholders::_1));
 

--- a/prototype2/multigrid/MultigridBase.h
+++ b/prototype2/multigrid/MultigridBase.h
@@ -28,10 +28,10 @@ struct Monitor {
   std::shared_ptr<ReadoutSerializer> readouts;
 
   void init(std::string broker, size_t max_readouts) {
-    readouts = std::make_shared<ReadoutSerializer>(max_readouts);
+    readouts = std::make_shared<ReadoutSerializer>(max_readouts, "multigrid");
     hists = std::make_shared<Hists>(std::numeric_limits<uint16_t>::max(),
                                     std::numeric_limits<uint16_t>::max());
-    histfb = std::make_shared<HistSerializer>(hists->needed_buffer_size());
+    histfb = std::make_shared<HistSerializer>(hists->needed_buffer_size(), "multigrid");
 
     producer = std::make_shared<Producer>(broker, "C-SPEC_monitor");
     readouts->set_callback(std::bind(&Producer::produce2<uint8_t>, producer.get(), std::placeholders::_1));

--- a/prototype2/sonde/SoNDeBase.cpp
+++ b/prototype2/sonde/SoNDeBase.cpp
@@ -111,7 +111,7 @@ void SONDEIDEABase::processing_thread() {
   constexpr uint16_t maxChannels{64};
   constexpr uint16_t maxAdc{65535};
   Hists histograms(maxChannels, maxAdc);
-  HistSerializer histfb(histograms.needed_buffer_size());
+  HistSerializer histfb(histograms.needed_buffer_size(), "SONDE");
   Producer monitorprod(EFUSettings.KafkaBroker, "SKADI_monitor");
   histfb.set_callback(
     std::bind(&Producer::produce2<uint8_t>, &monitorprod, std::placeholders::_1));


### PR DESCRIPTION
### Issue reference / description
We need these changes and we need them pretty much immediately to ensure that the flatbuffer schema contract between the EFU and daquiri is not broken. Apparently, we have been using the schema wrong in a few pipelines. This fix concerns two problems:
* Some of the fb schema (mo01 in particular) did not have full headers with flatbuffer schema id attached. This made it impossible to discriminate different types of messages on multiplexed topics. To achieve this, you have to close the builder with the schema-generated function, and not the generic builder one.
* Apparently there is an assumption that a "source_name" field must be included in all buffers for more granular filtering of messages -- again, further multiplexing.
* Tests have been improved to check for conformance with these assumptions.

The second of these expectations has come to me as a bit of a surprise, because while that may have been a working assumption for the file writer, this requirement was never explicitly conveyed to us.
In any case, these changes ensure that we conform to these assumptions. The code is not perfect. The classes in question are scheduled to be rewritten anyways. We need these changed merged now to ensure compatibility with daquiri, as changes therein are required by Jonas at V20 to monitor multiplexed streams.

The branch you merge from should already reference an event-formation-unit github ticket number. You can add a descriptive title, but if an issue is referenced, you don't have to.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
