### PR TITLE
Update Conan registry in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG https_proxy
 ARG local_conan_server
 
 RUN apt-get update -y && \
-    apt-get --no-install-recommends -y install build-essential git python-pip cmake tzdata vim m4 && \
+    apt-get --no-install-recommends -y install build-essential git python-pip cmake tzdata vim m4 flex && \
     apt-get -y autoremove && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --upgrade pip==9.0.3 && pip install setuptools && \
 RUN conan profile new default
 
 # Replace the default profile and remotes with the ones from our Ubuntu build node
-ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.json" "/root/.conan/registry.json"
+ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/remotes.json" "/root/.conan/remotes.json"
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
 
 # Add local Conan server if one is defined in the environment

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -266,6 +266,9 @@ def get_macos_pipeline()
             // Delete workspace when build is done
                 cleanWs()
 
+                // temporary until all our repos have moved to using official flatbuffers conan package
+                sh "conan remove -f FlatBuffers/*"
+
                 abs_dir = pwd()
 
                 dir("${project}") {

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,7 +4,7 @@ cli11/1.6.0@bincrafters/stable
 fmt/5.2.0@bincrafters/stable
 google-benchmark/1.4.1-dm2@ess-dmsc/testing
 graylog-logger/1.1.5-dm1@ess-dmsc/stable
-gtest/1.8.1@bincrafters/stable
+gtest/3121b20-dm3@ess-dmsc/stable
 h5cpp/0.1.2@ess-dmsc/testing
 jsonformoderncpp/3.1.0@vthiery/stable
 libpcap/1.8.1@bincrafters/stable

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,18 +1,17 @@
 [requires]
 asio/1.12.0@bincrafters/stable
 cli11/1.6.0@bincrafters/stable
-cmake_installer/3.10.0@conan/stable
 fmt/5.2.0@bincrafters/stable
 google-benchmark/1.4.1-dm2@ess-dmsc/testing
-graylog-logger/1.1.2-dm1@ess-dmsc/stable
-gtest/3121b20-dm3@ess-dmsc/stable
+graylog-logger/1.1.5-dm1@ess-dmsc/stable
+gtest/1.8.1@bincrafters/stable
 h5cpp/0.1.2@ess-dmsc/testing
 jsonformoderncpp/3.1.0@vthiery/stable
 libpcap/1.8.1@bincrafters/stable
-librdkafka/0.11.5@ess-dmsc/stable
+librdkafka/0.11.5-dm2@ess-dmsc/stable
 logical-geometry/09097f2@ess-dmsc/stable
 readerwriterqueue/07e22ec@ess-dmsc/stable
-streaming-data-types/6cd05e4@ess-dmsc/stable
+streaming-data-types/c45d2ec@ess-dmsc/stable
 trompeloeil/v31@ess-dmsc/stable
 
 [generators]


### PR DESCRIPTION
Fixes problem with latest version of Conan (1.15.0) where `registry.json` was renamed to `remotes.json`. This would cause our Dockerfile to fail to build.

Updated some conan packages to latest versions.

If docker-based system tests pass then this should be good to merge.