### PR TITLE
Use conan global config in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --upgrade pip==9.0.3 && pip install setuptools && \
 RUN conan profile new default
 
 # Replace the default profile and remotes with the ones from our Ubuntu build node
-ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/remotes.json" "/root/.conan/remotes.json"
+RUN conan config install http://github.com/ess-dmsc/conan-configuration.git
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
 
 # Add local Conan server if one is defined in the environment


### PR DESCRIPTION
### Issue reference / description

Change to use the conan configuration repository to set remotes in Docker image.

If the system tests pass then this PR is safe to merge.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
