### PR TITLE
Modernise Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ builders = pipeline_builder.createBuilders { container ->
                 mkdir build
                 cd build
                 conan remote add --insert 0 ess-dmsc-local ${local_conan_server}
+                conan install --build=outdated ..
             """
         }  // stage
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,8 +163,8 @@ builders = pipeline_builder.createBuilders { container ->
         }  // stage
     }
     
-    if (container.key == archive_what)
-        def docker_archive(image_key) {
+    if (container.key == archive_what) {
+        pipeline_builder.stage("${container.key}: archive") {
             container.sh """
                                 mkdir -p archive/event-formation-unit
                                 cp -r ${project}/build/bin archive/event-formation-unit

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,7 +155,7 @@ builders = pipeline_builder.createBuilders { container ->
         }  // stage
     } else if (container.key != clangformat_os) {
         pipeline_builder.stage("${container.key}: tests") {
-            sh """
+            container.sh """
                 cd ${project}/build
                 . ./activate_run.sh
                 make runtest

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,8 +206,9 @@ def get_macos_pipeline()
             // Delete workspace when build is done
                 cleanWs()
 
-                // temporary until all our repos have moved to using official flatbuffers conan package
+                // temporary until all our repos have moved to using official flatbuffers and CLI11 conan packages
                 sh "conan remove -f FlatBuffers/*"
+                sh "conan remove -f cli11/*"
 
                 abs_dir = pwd()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ builders = pipeline_builder.createBuilders { container ->
         
         pipeline_builder.stage("${container.key}: configure") {
         def xtra_flags = ""
-        if container.key == coverage_on {
+        if (container.key == coverage_on) {
             xtra_flags = "DCOV=ON"
         } else if (container.key == archive_what) {
             xtra_flags = "-DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,6 @@ builders = pipeline_builder.createBuilders { container ->
     if (container.key != clangformat_os) {
         pipeline_builder.stage("${container.key}: get dependencies") {
             container.sh """
-                mkdir ${project}
                 cd ${project}
                 mkdir build
                 cd build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,7 @@
+@Library('ecdc-pipeline')
+import ecdcpipeline.ContainerBuildNode
+import ecdcpipeline.PipelineBuilder
+
 project = "event-formation-unit"
 coverage_on = "centos7"
 clangformat_os = "debian9"
@@ -15,30 +19,12 @@ archive_what = "centos7-release"
      ]
  ]]);
 
-images = [
-    'centos7-release': [
-        'name': 'screamingudder/centos7-build-node:4.3.0',
-        'sh': '/usr/bin/scl enable devtoolset-6 -- /bin/bash -e',
-        'cmake_flags': '-DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON'
-    ],
-    'centos7': [
-        'name': 'screamingudder/centos7-build-node:4.3.0',
-        'sh': '/usr/bin/scl enable devtoolset-6 -- /bin/bash -e',
-        'cmake_flags': '-DCOV=ON'
-    ],
-    'ubuntu1804': [
-        'name': 'essdmscdm/ubuntu18.04-build-node:2.1.0',
-        'sh': 'bash -e',
-        'cmake_flags': ''
-    ],
-    'debian9': [
-        'name': 'essdmscdm/debian9-build-node:3.1.0',
-        'sh'  : 'bash -e',
-        'cmake_flags': ''
-    ]
+container_build_nodes = [
+  'centos7': ContainerBuildNode.getDefaultContainerBuildNode('centos7'),
+  'centos7-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7'),
+  'debian9': ContainerBuildNode.getDefaultContainerBuildNode('debian9'),
+  'ubuntu1804': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804')
 ]
-
-base_container_name = "${project}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
 
 def failure_function(exception_obj, failureMessage) {
     def toEmails = [[$class: 'DevelopersRecipientProvider']]
@@ -48,212 +34,164 @@ def failure_function(exception_obj, failureMessage) {
     throw exception_obj
 }
 
-def Object container_name(image_key) {
-    return "${base_container_name}-${image_key}"
-}
+pipeline_builder = new PipelineBuilder(this, container_build_nodes)
+pipeline_builder.activateEmailFailureNotifications()
 
-def Object get_container(image_key) {
-    def image = docker.image(images[image_key]['name'])
-    def container = image.run("\
-        --name ${container_name(image_key)} \
-        --tty \
-        --env http_proxy=${env.http_proxy} \
-        --env https_proxy=${env.https_proxy} \
-        --env local_conan_server=${env.local_conan_server} \
-        --mount=type=bind,src=/home/jenkins/data,dst=/home/jenkins/refdata,readonly \
-        ")
-    return container
-}
+builders = pipeline_builder.createBuilders { container ->
 
-def docker_copy_code(image_key) {
-    def custom_sh = images[image_key]['sh']
-    dir("${project}_code") {
-        checkout scm
+    pipeline_builder.stage("${container.key}: checkout") {
+        dir(pipeline_builder.project) {
+            scm_vars = checkout scm
+        }
+        // Copy source code to container
+        container.copyTo(pipeline_builder.project, pipeline_builder.project)
+    }  // stage
+
+    
+    if (container.key != clangformat_os) {
+        pipeline_builder.stage("${container.key}: get dependencies") {
+            container.sh """
+                mkdir build
+                cd build
+                conan remote add --insert 0 ess-dmsc-local ${local_conan_server}
+            """
+        }  // stage
+        
+        
+        pipeline_builder.stage("${container.key}: configure") {
+        def xtra_flags = ""
+        if container.key == coverage_on {
+            xtra_flags = "DCOV=ON"
+        } else if (container.key == archive_what) {
+            xtra_flags = "-DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON"
+        }
+        container.sh """
+            cd ${project}
+            cd build
+            . ./activate_run.sh
+            cmake --version
+            cmake -DREFDATA=/home/jenkins/refdata/EFU_reference -DCONAN=MANUAL -DGOOGLE_BENCHMARK=ON ${xtra_flags} ..
+        """
+        }  // stage
+        
+        pipeline_builder.stage("${container.key}: build") {
+            container.sh """
+                cd ${project}/build
+                make --version
+                make all unit_tests benchmark -j4
+                cd ../utils/udpredirect
+                make
+            """
+        }  // stage
     }
-    sh "docker cp ${project}_code ${container_name(image_key)}:/home/jenkins/${project}"
-    sh """docker exec --user root ${container_name(image_key)} ${custom_sh} -c \"
-                        chown -R jenkins.jenkins /home/jenkins/${project}
-                        \""""
-}
+    
+    if (container.key == clangformat_os) {
+    pipeline_builder.stage("${container.key}: cppcheck") {
+        try {
+                def test_output = "cppcheck.txt"
+                container.sh """
+                                cd ${project}
+                                cppcheck --enable=all --inconclusive --template="{file},{line},{severity},{id},{message}" ./ 2> ${test_output}
+                            """
+                container.copyFrom("${project}", '.')
+                sh "mv -f ./${project}/* ./"
+            } catch (e) {
+                failure_function(e, "Cppcheck step for (${container.key}) failed")
+            }
+        }  // stage
+        step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: "cppcheck.txt"]]])
+    }
+       
+    if (container.key == coverage_on) {
+        pipeline_builder.stage("${container.key}: test coverage") {
+            abs_dir = pwd()
 
-def docker_dependencies(image_key) {
-    def conan_remote = "ess-dmsc-local"
-    def custom_sh = images[image_key]['sh']
-    sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
-        mkdir ${project}/build
-        cd ${project}/build
-        conan remote add \
-            --insert 0 \
-            ${conan_remote} ${local_conan_server}
-        conan install --build=outdated ..
-    \""""
-}
-
-def docker_cmake(image_key, xtra_flags) {
-    def custom_sh = images[image_key]['sh']
-    sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
-        cd ${project}
-        cd build
-        . ./activate_run.sh
-        cmake --version
-        cmake -DREFDATA=/home/jenkins/refdata/EFU_reference -DCONAN=MANUAL -DGOOGLE_BENCHMARK=ON ${xtra_flags} ..
-    \""""
-}
-
-def docker_build(image_key) {
-    def custom_sh = images[image_key]['sh']
-    sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
-        cd ${project}/build
-        make --version
-        make all unit_tests benchmark -j4
-        cd ../utils/udpredirect
-        make
-    \""""
-}
-
-def docker_cppcheck(image_key) {
-    try {
-        def custom_sh = images[image_key]['sh']
-        def test_output = "cppcheck.txt"
-        def cppcheck_script = """
-                        cd ${project}
-                        cppcheck --enable=all --inconclusive --template="{file},{line},{severity},{id},{message}" ./ 2> ${test_output}
+            try {
+                container.sh """
+                        cd ${project}/build
+                        . ./activate_run.sh
+                        make -j 4 runefu
+                        make coverage
+                        echo skipping make -j 4 valgrind
                     """
-        sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
-        sh "docker cp ${container_name(image_key)}:/home/jenkins/${project} ."
-        sh "mv -f ./${project}/* ./"
-    } catch (e) {
-        failure_function(e, "Cppcheck step for (${container_name(image_key)}) failed")
-    }
-}
+                container.copyFrom("${project}", '.')
+            } catch(e) {
+                container.copyFrom("${project}/build/test_results", '.')
+                junit 'test_results/*.xml'
+                failure_function(e, 'Run tests (${container.key}) failed')
+            }
 
-def docker_tests(image_key) {
-    def custom_sh = images[image_key]['sh']
-    sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
-        cd ${project}/build
-        . ./activate_run.sh
-        make runtest
-        make runefu
-    \""""
-}
+            dir("${project}/build") {
+                    junit 'test_results/*.xml'
+                    sh "../jenkins/redirect_coverage.sh ./coverage/coverage.xml ${abs_dir}/${project}"
 
-def docker_tests_coverage(image_key) {
-    def custom_sh = images[image_key]['sh']
-    abs_dir = pwd()
-
-    try {
-        sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
+                    step([
+                        $class: 'CoberturaPublisher',
+                        autoUpdateHealth: true,
+                        autoUpdateStability: true,
+                        coberturaReportFile: 'coverage/coverage.xml',
+                        failUnhealthy: false,
+                        failUnstable: false,
+                        maxNumberOfBuilds: 0,
+                        onlyStable: false,
+                        sourceEncoding: 'ASCII',
+                        zoomCoverageChart: true
+                    ])
+                    // step([$class: 'ValgrindPublisher',
+                    //      pattern: 'memcheck_res/*.valgrind',
+                    //      failBuildOnMissingReports: true,
+                    //      failBuildOnInvalidReports: true,
+                    //      publishResultsForAbortedBuilds: false,
+                    //      publishResultsForFailedBuilds: false,
+                    //      failThresholdInvalidReadWrite: '',
+                    //      unstableThresholdInvalidReadWrite: '',
+                    //      failThresholdDefinitelyLost: '',
+                    //      unstableThresholdDefinitelyLost: '',
+                    //      failThresholdTotal: '',
+                    //      unstableThresholdTotal: '99'
+                    //])
+            }
+        }  // stage
+    } else if (container.key != clangformat_os) {
+        pipeline_builder.stage("${container.key}: tests") {
+            sh """
                 cd ${project}/build
                 . ./activate_run.sh
-                make -j 4 runefu
-                make coverage
-                echo skipping make -j 4 valgrind
-            \""""
-        sh "docker cp ${container_name(image_key)}:/home/jenkins/${project} ./"
-    } catch(e) {
-        sh "docker cp ${container_name(image_key)}:/home/jenkins/${project}/build/test_results ./"
-        junit 'test_results/*.xml'
-        failure_function(e, 'Run tests (${container_name(image_key)}) failed')
+                make runtest
+                make runefu
+            """
+        }  // stage
     }
+    
+    if (container.key == archive_what)
+        def docker_archive(image_key) {
+            container.sh """
+                                mkdir -p archive/event-formation-unit
+                                cp -r ${project}/build/bin archive/event-formation-unit
+                                cp -r ${project}/build/modules archive/event-formation-unit
+                                cp -r ${project}/build/lib archive/event-formation-unit
+                                cp -r ${project}/build/licenses archive/event-formation-unit
+                                mkdir archive/event-formation-unit/util
+                                cp -r ${project}/utils/efushell archive/event-formation-unit/util
+                                mkdir archive/event-formation-unit/configs
+                                cp -r ${project}/prototype2/multiblade/configs/* archive/event-formation-unit/configs/
+                                cp -r ${project}/prototype2/multigrid/configs/* archive/event-formation-unit/configs/
+                                cp -r ${project}/prototype2/gdgem/configs/* archive/event-formation-unit/configs/
+                                cp ${project}/utils/udpredirect/udpredirect archive/event-formation-unit/util
+                                mkdir archive/event-formation-unit/data
+                                cd archive
+                                tar czvf event-formation-unit-centos7.tar.gz event-formation-unit
 
-    dir("${project}/build") {
-            junit 'test_results/*.xml'
-            sh "../jenkins/redirect_coverage.sh ./coverage/coverage.xml ${abs_dir}/${project}"
-
-            step([
-                $class: 'CoberturaPublisher',
-                autoUpdateHealth: true,
-                autoUpdateStability: true,
-                coberturaReportFile: 'coverage/coverage.xml',
-                failUnhealthy: false,
-                failUnstable: false,
-                maxNumberOfBuilds: 0,
-                onlyStable: false,
-                sourceEncoding: 'ASCII',
-                zoomCoverageChart: true
-            ])
-            // step([$class: 'ValgrindPublisher',
-            //      pattern: 'memcheck_res/*.valgrind',
-            //      failBuildOnMissingReports: true,
-            //      failBuildOnInvalidReports: true,
-            //      publishResultsForAbortedBuilds: false,
-            //      publishResultsForFailedBuilds: false,
-            //      failThresholdInvalidReadWrite: '',
-            //      unstableThresholdInvalidReadWrite: '',
-            //      failThresholdDefinitelyLost: '',
-            //      unstableThresholdDefinitelyLost: '',
-            //      failThresholdTotal: '',
-            //      unstableThresholdTotal: '99'
-            //])
-    }
-}
-
-def docker_archive(image_key) {
-    def custom_sh = images[image_key]['sh']
-    sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
-                        mkdir -p archive/event-formation-unit
-                        cp -r ${project}/build/bin archive/event-formation-unit
-                        cp -r ${project}/build/modules archive/event-formation-unit
-                        cp -r ${project}/build/lib archive/event-formation-unit
-                        cp -r ${project}/build/licenses archive/event-formation-unit
-                        mkdir archive/event-formation-unit/util
-                        cp -r ${project}/utils/efushell archive/event-formation-unit/util
-                        mkdir archive/event-formation-unit/configs
-                        cp -r ${project}/prototype2/multiblade/configs/* archive/event-formation-unit/configs/
-                        cp -r ${project}/prototype2/multigrid/configs/* archive/event-formation-unit/configs/
-                        cp -r ${project}/prototype2/gdgem/configs/* archive/event-formation-unit/configs/
-                        cp ${project}/utils/udpredirect/udpredirect archive/event-formation-unit/util
-                        mkdir archive/event-formation-unit/data
-                        cd archive
-                        tar czvf event-formation-unit-centos7.tar.gz event-formation-unit
-
-                        # Create file with build information
-                        touch BUILD_INFO
-                        echo 'Repository: ${project}/${env.BRANCH_NAME}' >> BUILD_INFO
-                        echo 'Commit: ${scm_vars.GIT_COMMIT}' >> BUILD_INFO
-                        echo 'Jenkins build: ${BUILD_NUMBER}' >> BUILD_INFO
-                    \""""
-
-    sh "docker cp ${container_name(image_key)}:/home/jenkins/archive/event-formation-unit-centos7.tar.gz ."
-    sh "docker cp ${container_name(image_key)}:/home/jenkins/archive/BUILD_INFO ."
-    archiveArtifacts "event-formation-unit-centos7.tar.gz,BUILD_INFO"
-}
-
-def get_pipeline(image_key)
-{
-    return {
-        node('docker') {
-            stage("${image_key}") {
-                try {
-                    def container = get_container(image_key)
-
-                    docker_copy_code(image_key)
-                    if (image_key != clangformat_os) {
-                      docker_dependencies(image_key)
-                      docker_cmake(image_key, images[image_key]['cmake_flags'])
-                      docker_build(image_key)
-                    }
-
-                    if (image_key == coverage_on) {
-                        docker_tests_coverage(image_key)
-                    } else if (image_key != clangformat_os) {
-                      docker_tests(image_key)
-                    }
-
-                    if (image_key == archive_what) {
-                        docker_archive(image_key)
-                    }
-
-                    if (image_key == clangformat_os) {
-                        docker_cppcheck(image_key)
-                        step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: "cppcheck.txt"]]])
-                    }
-                } finally {
-                    sh "docker stop ${container_name(image_key)}"
-                    sh "docker rm -f ${container_name(image_key)}"
-                    cleanWs()
-                }
-            }
+                                # Create file with build information
+                                touch BUILD_INFO
+                                echo 'Repository: ${project}/${env.BRANCH_NAME}' >> BUILD_INFO
+                                echo 'Commit: ${scm_vars.GIT_COMMIT}' >> BUILD_INFO
+                                echo 'Jenkins build: ${BUILD_NUMBER}' >> BUILD_INFO
+                            """
+            container.copyFrom("/home/jenkins/archive/event-formation-unit-centos7.tar.gz", '.')
+            container.copyFrom("/home/jenkins/archive/BUILD_INFO", '.')
+            
+            archiveArtifacts "event-formation-unit-centos7.tar.gz,BUILD_INFO"
         }
     }
 }
@@ -346,13 +284,6 @@ node('docker') {
                 failure_function(e, 'Static analysis failed')
             }
         }
-    }
-
-    def builders = [:]
-
-    for (x in images.keySet()) {
-        def image_key = x
-        builders[image_key] = get_pipeline(image_key)
     }
 
     builders['macOS'] = get_macos_pipeline()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,8 @@ builders = pipeline_builder.createBuilders { container ->
     if (container.key != clangformat_os) {
         pipeline_builder.stage("${container.key}: get dependencies") {
             container.sh """
+                mkdir ${project}
+                cd ${project}
                 mkdir build
                 cd build
                 conan remote add --insert 0 ess-dmsc-local ${local_conan_server}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,19 +61,18 @@ builders = pipeline_builder.createBuilders { container ->
         
         
         pipeline_builder.stage("${container.key}: configure") {
-        def xtra_flags = ""
-        if (container.key == coverage_on) {
-            xtra_flags = "DCOV=ON"
-        } else if (container.key == archive_what) {
-            xtra_flags = "-DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON"
-        }
-        container.sh """
-            cd ${project}
-            cd build
-            . ./activate_run.sh
-            cmake --version
-            cmake -DREFDATA=/home/jenkins/refdata/EFU_reference -DCONAN=MANUAL -DGOOGLE_BENCHMARK=ON ${xtra_flags} ..
-        """
+            def xtra_flags = ""
+            if (container.key == coverage_on) {
+                xtra_flags = "-DCOV=ON"
+            } else if (container.key == archive_what) {
+                xtra_flags = "-DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON"
+            }
+            container.sh """
+                cd ${project}/build
+                . ./activate_run.sh
+                cmake --version
+                cmake -DREFDATA=/home/jenkins/refdata/EFU_reference -DCONAN=MANUAL -DGOOGLE_BENCHMARK=ON ${xtra_flags} ..
+            """
         }  // stage
         
         pipeline_builder.stage("${container.key}: build") {
@@ -88,7 +87,7 @@ builders = pipeline_builder.createBuilders { container ->
     }
     
     if (container.key == clangformat_os) {
-    pipeline_builder.stage("${container.key}: cppcheck") {
+        pipeline_builder.stage("${container.key}: cppcheck") {
         try {
                 def test_output = "cppcheck.txt"
                 container.sh """

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-asio/1.12.0@bincrafters/stable
+asio/1.13.0@bincrafters/stable
 CLI11/1.8.0@cliutils/stable 
 fmt/5.2.0@bincrafters/stable
 google-benchmark/1.4.1-dm2@ess-dmsc/testing

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 asio/1.12.0@bincrafters/stable
-cli11/1.6.0@bincrafters/stable
+CLI11/1.8.0@cliutils/stable 
 fmt/5.2.0@bincrafters/stable
 google-benchmark/1.4.1-dm2@ess-dmsc/testing
 graylog-logger/1.1.5-dm1@ess-dmsc/stable
@@ -11,7 +11,7 @@ libpcap/1.8.1@bincrafters/stable
 librdkafka/0.11.5-dm2@ess-dmsc/stable
 logical-geometry/09097f2@ess-dmsc/stable
 readerwriterqueue/07e22ec@ess-dmsc/stable
-streaming-data-types/c45d2ec@ess-dmsc/stable
+streaming-data-types/fb4d847@ess-dmsc/stable
 trompeloeil/v31@ess-dmsc/stable
 
 [generators]


### PR DESCRIPTION
### Issue reference / description

Part of DM-972

Changed to use the jenkins-shared-library in the Jenkinsfile.
This reduces the boilerplate code a little and ensures that the latest build node images are used without having to update the Jenkinsfile.

Updated the streaming-data-types, CLI11 and asio package versions.

*Reviewer:*
Please check that all the expected build artifacts and coverage reports are successfully produced before merging this pull request.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
