### PR TITLE
Dm 1838 kafka timestamps in VIP demo

### DIFF
--- a/src/gdgem/GdGemBase.h
+++ b/src/gdgem/GdGemBase.h
@@ -75,11 +75,7 @@ protected:
 
   ReducedEvent neutron_event_;
 
-  uint64_t previous_full_time_{0};
-  uint64_t recent_pulse_time_{0};
-  bool have_pulse_time_{false};
-
-  uint64_t truncated_time_;
+  uint64_t CurrentPulseTime {0}; /// \todo get PT from data eventually
   uint32_t pixelid_;
 
   bool sample_next_track_ {false};

--- a/src/multigrid/MultigridBase.cpp
+++ b/src/multigrid/MultigridBase.cpp
@@ -57,7 +57,6 @@ MultigridBase::MultigridBase(BaseSettings const &settings, MultigridSettings con
   Stats.create("events_multiplicity_rejects", Counters.events_multiplicity_rejects);
   Stats.create("events_bad", Counters.events_bad);
   Stats.create("events_geometry_err", Counters.events_geometry_err);
-  Stats.create("events_time_err", Counters.events_time_err);
   Stats.create("tx_events", Counters.tx_events);
   Stats.create("tx_bytes", Counters.tx_bytes);
 
@@ -109,33 +108,16 @@ void MultigridBase::process_events(EV42Serializer &ev42serializer) {
     if (event.pixel_id == 0) {
       Counters.pulses++;
 
-      if (HavePulseTime) {
-        uint64_t PulsePeriod = event.time - ev42serializer.pulseTime();
-        ShortestPulsePeriod = std::min(ShortestPulsePeriod, PulsePeriod);
-      }
-      HavePulseTime = true;
-
-      if (ev42serializer.eventCount())
+      if (ev42serializer.eventCount()) {
         Counters.tx_bytes += ev42serializer.produce();
-      ev42serializer.pulseTime(event.time);
-
-//            XTRACE(PROCESS, DEB, "New pulse time: %u   shortest pulse period: %u",
-//                   ev42serializer.pulseTime(), ShortestPulsePeriod);
-    } else {
-
-      auto time = static_cast<uint32_t>(event.time - ev42serializer.pulseTime());
-//            XTRACE(PROCESS, DEB, "Event: pixel: %d, time: %d ", pixel, time);
-      if (!HavePulseTime || (event.time < ev42serializer.pulseTime())) {
-        XTRACE(PROCESS, DEB, "Event before pulse");
-        Counters.events_time_err++;
-      } else if (time > (1.00004 * ShortestPulsePeriod)) {
-        XTRACE(PROCESS, DEB, "Event out of pulse range");
-        Counters.events_time_err++;
-      } else {
-//              XTRACE(PROCESS, DEB, "Event good");
-        Counters.tx_events++;
-        Counters.tx_bytes += ev42serializer.addEvent(time, event.pixel_id);
       }
+      uint64_t EfuTime = 1000000000LU * (uint64_t)time(NULL); // ns since 1970
+      ev42serializer.pulseTime(EfuTime);
+
+    } else {
+      auto TOF = static_cast<uint32_t>(event.time); /// \todo this is NOT TOF
+      Counters.tx_events++;
+      Counters.tx_bytes += ev42serializer.addEvent(TOF, event.pixel_id);
     }
   }
   mg_config.reduction.out_queue.clear();

--- a/src/multigrid/MultigridBase.h
+++ b/src/multigrid/MultigridBase.h
@@ -57,7 +57,6 @@ protected:
     int64_t events_multiplicity_rejects{0};
     int64_t events_bad{0};
     int64_t events_geometry_err{0};
-    int64_t events_time_err{0};
     int64_t tx_events{0};
     int64_t tx_bytes{0};
     // Kafka stats below are common to all detectors

--- a/src/multigrid/test/MultigridBaseTest.cpp
+++ b/src/multigrid/test/MultigridBaseTest.cpp
@@ -72,9 +72,7 @@ TEST_F(MultigridBaseTest, DataReceive) {
   EXPECT_EQ(Readout.Counters.events_multiplicity_rejects, 1);
   EXPECT_EQ(Readout.Counters.events_bad, 0);
   EXPECT_EQ(Readout.Counters.events_geometry_err, 0);
-  EXPECT_EQ(Readout.Counters.events_time_err, 22);
-  EXPECT_EQ(Readout.Counters.tx_events, 0);
-  EXPECT_EQ(Readout.Counters.tx_bytes, 0);
+  EXPECT_EQ(Readout.Counters.tx_events, 22);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
### Issue reference / description

Non of the timestamps in the kafka produce calls were correct. Produce time should 
now approximately be correct, pulse time is just unix time and thus not yet a pulse time.

Some hacks were done for GdGEM and MultiGrid to create fake pulse times, but these 
have now been removed. All unit test pass and I have verified locally that 'correct' timestamps
are present.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
