### PR TITLE
make cmake build RelWithDebInfo use same optimzer settings as Release…

### DIFF
--- a/cmake/CompilerConfig.cmake
+++ b/cmake/CompilerConfig.cmake
@@ -10,6 +10,7 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(EXTRA_CXX_FLAGS "-Werror -Wall -Wpedantic -Wextra")
 set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -O3 -DRELEASE -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} -g")
 #set(CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE} "-ggdb -fno-omit-frame-pointer")
 
 add_definitions("-D__FAVOR_BSD") #Not working correctly?


### PR DESCRIPTION
… builds

### Issue reference / description

**This will make RelWithDebInfo generated the same code as Release, however it can be profiled efficiently.**

https://github.com/ess-dmsc/event-formation-unit/issues/338

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
