### PR TITLE
ECDC-1626 Update path to refdata in Jenkins nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ def failure_function(exception_obj, failureMessage) {
     throw exception_obj
 }
 
-pipeline_builder = new PipelineBuilder(this, container_build_nodes, "/home/jenkins/data:/home/jenkins/refdata")
+pipeline_builder = new PipelineBuilder(this, container_build_nodes, "/mnt/data:/home/jenkins/refdata")
 pipeline_builder.activateEmailFailureNotifications()
 
 builders = pipeline_builder.createBuilders { container ->


### PR DESCRIPTION
### Issue reference / description

Change the path to refdata to be mounted in containers running the Jenkins job. Data are available in the new path, but the old path will remain available at least until this is merged into master.

## Checklist for submitter

- [x] Check for conflict with integration test
- [x] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
