### PR TITLE
Use std::filesystem rather than boost where possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
 project("event-formation-unit")
 
-set(CMAKE_CXX_STANDARD 17)
-
 #=============================================================================
 # Augment CMake with our custom scripts
 #=============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
 project("event-formation-unit")
 
+set(CMAKE_CXX_STANDARD 17)
+
 #=============================================================================
 # Augment CMake with our custom scripts
 #=============================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM screamingudder/ubuntu18.04-build-node:3.0.0
+FROM screamingudder/ubuntu20.04-build-node:1.1.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ container_build_nodes = [
   'centos7': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
   'centos7-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
   'debian10': ContainerBuildNode.getDefaultContainerBuildNode('debian10'),
-  'ubuntu1804': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804-gcc8')
+  'ubuntu2004': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2004')
 ]
 
 def failure_function(exception_obj, failureMessage) {

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -14,6 +14,8 @@ readerwriterqueue/07e22ec@ess-dmsc/stable
 concurrentqueue/8f7e861@ess-dmsc/stable
 streaming-data-types/d356a77@ess-dmsc/stable
 trompeloeil/v38@rollbear/stable
+boost/1.75.0
+zlib/1.2.11
 
 [generators]
 cmake
@@ -22,7 +24,7 @@ cmake_find_package
 
 [options]
 librdkafka:shared=True
-h5cpp:with_boost=False
+h5cpp:with_boost=True
 
 [imports]
 lib, * -> ./lib

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,19 +1,19 @@
 [requires]
 asio/1.16.1
-CLI11/1.8.0@cliutils/stable
+CLI11/1.9.1@cliutils/stable
 fmt/6.2.0
-google-benchmark/1.4.1-dm2@ess-dmsc/testing
+benchmark/1.5.2
 graylog-logger/2.0.3-dm1@ess-dmsc/stable
-gtest/1.8.1@bincrafters/stable
-h5cpp/0.3.3@ess-dmsc/stable
+gtest/1.8.1
+h5cpp/0.4.0@ess-dmsc/stable
 jsonformoderncpp/3.7.0
 libpcap/1.8.1@bincrafters/stable
-librdkafka/0.11.5-dm2@ess-dmsc/stable
+librdkafka/1.5.0@ess-dmsc/stable
 logical-geometry/705ea61@ess-dmsc/stable
 readerwriterqueue/07e22ec@ess-dmsc/stable
 concurrentqueue/8f7e861@ess-dmsc/stable
-streaming-data-types/70c9a71@ess-dmsc/stable
-trompeloeil/v31@ess-dmsc/stable
+streaming-data-types/d356a77@ess-dmsc/stable
+trompeloeil/v38@rollbear/stable
 
 [generators]
 cmake
@@ -22,6 +22,7 @@ cmake_find_package
 
 [options]
 librdkafka:shared=True
+h5cpp:with_boost=False
 
 [imports]
 lib, * -> ./lib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,6 @@ set(EFU_COMMON_LIBS
   ${LibRDKafka_LIBRARIES}
   ${LibRDKafka_C_LIBRARIES}
   ${HDF5_C_LIBRARIES}
-  ${Boost_LIBRARIES}
   GraylogLogger::graylog_logger_static
   fmt::fmt
   h5cpp::h5cpp

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -31,6 +31,7 @@ set(efu_common_INC
   EV42Serializer.h
   Expect.h
   FixedSizePool.h
+  Filesystem.h
   JsonFile.h
   gccintel.h
   Log.h

--- a/src/common/Filesystem.h
+++ b/src/common/Filesystem.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <h5cpp/core/with_boost.hpp>
+
+#ifdef WITH_BOOST
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#else
+
+// Check for feature test macro for <filesystem>
+#if defined(__cpp_lib_filesystem)
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+
+// Check for feature test macro for <experimental/filesystem>
+#elif defined(__cpp_lib_experimental_filesystem)
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+// Can't check if headers exist so assume experimental to be safe
+#elif !defined(__has_include)
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+// Check if the header "<filesystem>" exists
+#elif __has_include(<filesystem>)
+
+// If we're compiling on Visual Studio and are not compiling with C++17, we need
+// to use experimental
+#ifdef _MSC_VER
+
+// Check and include header that defines "_HAS_CXX17"
+#if __has_include(<yvals_core.h>)
+#include <yvals_core.h>
+
+// Check for enabled C++17 support
+#if defined(_HAS_CXX17) && _HAS_CXX17
+// We're using C++17, so let's use the normal version
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+#endif
+#endif
+
+// If the marco isn't defined yet, that means any of the other VS specific
+// checks failed, so we need to use experimental
+#ifndef INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+#endif
+
+// Not on Visual Studio. Let's use the normal version
+#else // #ifdef _MSC_VER
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+#endif
+
+// Check if the header "<filesystem>" exists
+#elif __has_include(<experimental/filesystem>)
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+// Fail if neither header is available with a nice error message
+#else
+#error Could not find system header "<filesystem>" or "<experimental/filesystem>"
+#endif
+
+// We previously determined that we need the experimental version
+#if INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+// Include it
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+
+// We have a decent compiler and can use the normal version
+#else
+// Include it
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
+
+#endif

--- a/src/common/reduction/test/HitTest.cpp
+++ b/src/common/reduction/test/HitTest.cpp
@@ -8,9 +8,9 @@ protected:
   Hit hit;
   void SetUp() override {
     hdf5::error::Singleton::instance().auto_print(false);
-    if (boost::filesystem::exists("hit_file_test_00000.h5"))
+    if (fs::exists("hit_file_test_00000.h5"))
     {
-      boost::filesystem::remove("hit_file_test_00000.h5");
+      fs::remove("hit_file_test_00000.h5");
     }
   }
   void TearDown() override { }

--- a/src/common/test/DumpFileTest.cpp
+++ b/src/common/test/DumpFileTest.cpp
@@ -61,14 +61,14 @@ class DumpFileTest : public TestBase {
 protected:
   void SetUp() override {
     hdf5::error::Singleton::instance().auto_print(false);
-    if (boost::filesystem::exists("dumpfile_test_00000.h5"))
+    if (fs::exists("dumpfile_test_00000.h5"))
     {
-      boost::filesystem::remove("dumpfile_test_00000.h5");
+      fs::remove("dumpfile_test_00000.h5");
     }
 
-    if (boost::filesystem::exists("dumpfile_test_00001.h5"))
+    if (fs::exists("dumpfile_test_00001.h5"))
     {
-      boost::filesystem::remove("dumpfile_test_00001.h5");
+      fs::remove("dumpfile_test_00001.h5");
     }
   }
   void TearDown() override {}
@@ -124,7 +124,7 @@ TEST_F(DumpFileTest, PushFileRotation) {
 
   EXPECT_TRUE(hdf5::file::is_hdf5_file("dumpfile_test_00000.h5"));
 
-  EXPECT_FALSE(boost::filesystem::exists("dumpfile_test_00001.h5"));
+  EXPECT_FALSE(fs::exists("dumpfile_test_00001.h5"));
   file->push(std::vector<Hit>(300000, Hit()));
   EXPECT_TRUE(hdf5::file::is_hdf5_file("dumpfile_test_00001.h5"));
 }

--- a/src/common/test/KafkaMocks.h
+++ b/src/common/test/KafkaMocks.h
@@ -18,14 +18,15 @@
 
 // GCOVR_EXCL_START
 
-class MockProducer : public RdKafka::Producer {
+class MockProducer : public trompeloeil::mock_interface<RdKafka::Producer> {
 public:
   MAKE_CONST_MOCK0(name, const std::string(), override);
   MAKE_CONST_MOCK0(memberid, const std::string(), override);
   MAKE_MOCK1(poll, int(int), override);
   MAKE_MOCK0(outq_len, int(), override);
-  MAKE_MOCK4(metadata, RdKafka::ErrorCode(bool, const RdKafka::Topic *,
-                                          RdKafka::Metadata **, int),
+  MAKE_MOCK4(metadata,
+             RdKafka::ErrorCode(bool, const RdKafka::Topic *,
+                                RdKafka::Metadata **, int),
              override);
   MAKE_MOCK1(pause,
              RdKafka::ErrorCode(std::vector<RdKafka::TopicPartition *> &),
@@ -51,22 +52,44 @@ public:
   MAKE_MOCK1(clusterid, const std::string(int), override);
   MAKE_MOCK0(c_ptr, rd_kafka_s *(), override);
   MAKE_MOCK2(create, RdKafka::Producer *(RdKafka::Conf *, std::string));
-  MAKE_MOCK7(produce, RdKafka::ErrorCode(RdKafka::Topic *, int32_t, int, void *,
-                                         size_t, const std::string *, void *),
+  MAKE_MOCK7(produce,
+             RdKafka::ErrorCode(RdKafka::Topic *, int32_t, int, void *, size_t,
+                                const std::string *, void *),
              override);
-  MAKE_MOCK8(produce, RdKafka::ErrorCode(RdKafka::Topic *, int32_t, int, void *,
-                                         size_t, const void *, size_t, void *),
+  MAKE_MOCK8(produce,
+             RdKafka::ErrorCode(RdKafka::Topic *, int32_t, int, void *, size_t,
+                                const void *, size_t, void *),
              override);
   MAKE_MOCK9(produce,
              RdKafka::ErrorCode(const std::string, int32_t, int, void *, size_t,
                                 const void *, size_t, int64_t, void *),
              override);
-  MAKE_MOCK5(produce, RdKafka::ErrorCode(RdKafka::Topic *, int32_t,
-                                         const std::vector<char> *,
-                                         const std::vector<char> *, void *),
+  MAKE_MOCK5(produce,
+             RdKafka::ErrorCode(RdKafka::Topic *, int32_t,
+                                const std::vector<char> *,
+                                const std::vector<char> *, void *),
              override);
   MAKE_MOCK1(flush, RdKafka::ErrorCode(int), override);
   MAKE_MOCK1(controllerid, int32_t(int), override);
+  MAKE_CONST_MOCK1(fatal_error, RdKafka::ErrorCode(std::string &), override);
+  MAKE_MOCK5(oauthbearer_set_token,
+             RdKafka::ErrorCode(const std::string &, int64_t,
+                                const std::string &,
+                                const std::list<std::string> &, std::string &),
+             override);
+  MAKE_MOCK1(oauthbearer_set_token_failure,
+             RdKafka::ErrorCode(const std::string &), override);
+  MAKE_MOCK1(purge, RdKafka::ErrorCode(int), override);
+  IMPLEMENT_MOCK1(init_transactions);
+  IMPLEMENT_MOCK0(begin_transaction);
+  IMPLEMENT_MOCK3(send_offsets_to_transaction);
+  IMPLEMENT_MOCK1(commit_transaction);
+  IMPLEMENT_MOCK1(abort_transaction);
+  MAKE_MOCK10(produce,
+              RdKafka::ErrorCode(std::string, int32_t, int, void *, size_t,
+                                 const void *, size_t, int64_t,
+                                 RdKafka::Headers *, void *),
+              override);
 };
 
 class FakeTopic : public RdKafka::Topic {
@@ -86,54 +109,75 @@ public:
 class MockConf : public RdKafka::Conf {
 public:
   MAKE_MOCK3(set,
-               RdKafka::Conf::ConfResult(const std::string &,
-                                         const std::string &, std::string &), override);
-  MAKE_MOCK3(set, RdKafka::Conf::ConfResult(const std::string &,
-                                              RdKafka::DeliveryReportCb *,
-                                              std::string &), override);
+             RdKafka::Conf::ConfResult(const std::string &, const std::string &,
+                                       std::string &),
+             override);
   MAKE_MOCK3(set,
-               RdKafka::Conf::ConfResult(const std::string &,
-                                         RdKafka::EventCb *, std::string &), override);
+             RdKafka::Conf::ConfResult(const std::string &,
+                                       RdKafka::DeliveryReportCb *,
+                                       std::string &),
+             override);
   MAKE_MOCK3(set,
-               RdKafka::Conf::ConfResult(const std::string &,
-                                         const RdKafka::Conf *, std::string &), override);
-  MAKE_MOCK3(set, RdKafka::Conf::ConfResult(const std::string &,
-                                              RdKafka::PartitionerCb *,
-                                              std::string &), override);
+             RdKafka::Conf::ConfResult(const std::string &, RdKafka::EventCb *,
+                                       std::string &),
+             override);
   MAKE_MOCK3(set,
-               RdKafka::Conf::ConfResult(const std::string &,
-                                         RdKafka::PartitionerKeyPointerCb *,
-                                         std::string &), override);
+             RdKafka::Conf::ConfResult(const std::string &,
+                                       const RdKafka::Conf *, std::string &),
+             override);
   MAKE_MOCK3(set,
-               RdKafka::Conf::ConfResult(const std::string &,
-                                         RdKafka::SocketCb *, std::string &), override);
+             RdKafka::Conf::ConfResult(const std::string &,
+                                       RdKafka::PartitionerCb *, std::string &),
+             override);
   MAKE_MOCK3(set,
-               RdKafka::Conf::ConfResult(const std::string &, RdKafka::OpenCb *,
-                                         std::string &), override);
-  MAKE_MOCK3(set, RdKafka::Conf::ConfResult(const std::string &,
-                                              RdKafka::RebalanceCb *,
-                                              std::string &), override);
-  MAKE_MOCK3(set, RdKafka::Conf::ConfResult(const std::string &,
-                                              RdKafka::OffsetCommitCb *,
-                                              std::string &), override);
+             RdKafka::Conf::ConfResult(const std::string &,
+                                       RdKafka::PartitionerKeyPointerCb *,
+                                       std::string &),
+             override);
+  MAKE_MOCK3(set,
+             RdKafka::Conf::ConfResult(const std::string &, RdKafka::SocketCb *,
+                                       std::string &),
+             override);
+  MAKE_MOCK3(set,
+             RdKafka::Conf::ConfResult(const std::string &, RdKafka::OpenCb *,
+                                       std::string &),
+             override);
+  MAKE_MOCK3(set,
+             RdKafka::Conf::ConfResult(const std::string &,
+                                       RdKafka::RebalanceCb *, std::string &),
+             override);
+  MAKE_MOCK3(set,
+             RdKafka::Conf::ConfResult(const std::string &,
+                                       RdKafka::OffsetCommitCb *,
+                                       std::string &),
+             override);
 
-  MAKE_CONST_MOCK2(get, RdKafka::Conf::ConfResult(const std::string &,
-                                                    std::string &), override);
-  MAKE_CONST_MOCK1(get,
-                     RdKafka::Conf::ConfResult(RdKafka::DeliveryReportCb *&), override);
-  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::EventCb *&), override);
-  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::PartitionerCb *&), override);
+  MAKE_CONST_MOCK2(get,
+                   RdKafka::Conf::ConfResult(const std::string &,
+                                             std::string &),
+                   override);
+  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::DeliveryReportCb *&),
+                   override);
+  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::EventCb *&),
+                   override);
+  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::PartitionerCb *&),
+                   override);
   MAKE_CONST_MOCK1(
-                     get, RdKafka::Conf::ConfResult(RdKafka::PartitionerKeyPointerCb *&), override);
-  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::SocketCb *&), override);
-  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::OpenCb *&), override);
-  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::RebalanceCb *&), override);
-  MAKE_CONST_MOCK1(get,
-                     RdKafka::Conf::ConfResult(RdKafka::OffsetCommitCb *&), override);
+      get, RdKafka::Conf::ConfResult(RdKafka::PartitionerKeyPointerCb *&),
+      override);
+  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::SocketCb *&),
+                   override);
+  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::OpenCb *&),
+                   override);
+  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::RebalanceCb *&),
+                   override);
+  MAKE_CONST_MOCK1(get, RdKafka::Conf::ConfResult(RdKafka::OffsetCommitCb *&),
+                   override);
 
   MAKE_MOCK3(set,
-               RdKafka::Conf::ConfResult(const std::string &,
-                                         RdKafka::ConsumeCb *, std::string &), override);
+             RdKafka::Conf::ConfResult(const std::string &,
+                                       RdKafka::ConsumeCb *, std::string &),
+             override);
   MAKE_MOCK0(dump, std::list<std::string> *(), override);
 };
 // GCOVR_EXCL_STOP

--- a/src/efu/main.cpp
+++ b/src/efu/main.cpp
@@ -7,7 +7,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include <boost/filesystem.hpp>
+#include <common/Filesystem.h>
 #include <cstdlib>
 #include <common/EFUArgs.h>
 #include <common/StatPublisher.h>
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
 
     /// Automatically create the Graphite metric prefix from detector plugin name
     /// remove leading path and trailing extension
-    auto p = boost::filesystem::path(efu_args.getDetectorName()).filename().stem().string();
+    auto p = fs::path(efu_args.getDetectorName()).filename().stem().string();
     DetectorSettings.GraphitePrefix = std::string("efu.") + p;
 
     detector = loader.createDetector(DetectorSettings);

--- a/src/modules/gdgem/nmx/ReadoutTest.cpp
+++ b/src/modules/gdgem/nmx/ReadoutTest.cpp
@@ -8,9 +8,9 @@ using namespace Gem;
 class NMXReadoutTest : public TestBase {
 protected:
   void SetUp() override {
-    if (boost::filesystem::exists("readout_file_test_00000.h5"))
+    if (fs::exists("readout_file_test_00000.h5"))
     {
-      boost::filesystem::remove("readout_file_test_00000.h5");
+      fs::remove("readout_file_test_00000.h5");
     }
   }
   void TearDown() override {}

--- a/src/modules/jalousie/Config.cpp
+++ b/src/modules/jalousie/Config.cpp
@@ -39,7 +39,7 @@ Config::Config(std::string jsonfile) {
     return;
   }
 
-  auto root_dir = boost::filesystem::path(jsonfile).parent_path();
+  auto root_dir = fs::path(jsonfile).parent_path();
 
   std::string SUMO_mappings_file = root["SUMO_mappings_file"];
   nlohmann::json modules = root["modules"];

--- a/src/modules/jalousie/generators/CdtFile.cpp
+++ b/src/modules/jalousie/generators/CdtFile.cpp
@@ -38,7 +38,7 @@ const uint64_t kMetaDataSubIndex1{uint64_t(0x1) << 54};
 // const uint64_t kMetaDataSubIndex9{uint64_t(0x9) << 54};
 // const uint64_t kMetaDataSubIndex10{uint64_t(0xA) << 54};
 
-CdtFile::CdtFile(const boost::filesystem::path &FilePath) {
+CdtFile::CdtFile(const fs::path &FilePath) {
   Data.reserve(ChunkSize);
 
   file_.open(FilePath.string(), std::ios::binary);

--- a/src/modules/jalousie/generators/CdtFile.h
+++ b/src/modules/jalousie/generators/CdtFile.h
@@ -14,7 +14,7 @@ namespace Jalousie {
 
 class CdtFile {
 public:
-  CdtFile(const boost::filesystem::path &FilePath);
+  CdtFile(const fs::path &FilePath);
 
   size_t total() const;
   size_t read();

--- a/src/modules/jalousie/test/ReadoutTest.cpp
+++ b/src/modules/jalousie/test/ReadoutTest.cpp
@@ -9,9 +9,9 @@ class JalSumoMappingsTest : public TestBase {
 protected:
   void SetUp() override {
     hdf5::error::Singleton::instance().auto_print(false);
-    if (boost::filesystem::exists("hit_file_test_00000.h5"))
+    if (fs::exists("hit_file_test_00000.h5"))
     {
-      boost::filesystem::remove("hit_file_test_00000.h5");
+      fs::remove("hit_file_test_00000.h5");
     }
   }
   void TearDown() override {}

--- a/src/modules/multiblade/caen/ReadoutTest.cpp
+++ b/src/modules/multiblade/caen/ReadoutTest.cpp
@@ -9,9 +9,9 @@ class MGHitTest : public TestBase {
 protected:
   void SetUp() override {
     hdf5::error::Singleton::instance().auto_print(false);
-    if (boost::filesystem::exists("hit_file_test_00000.h5"))
+    if (fs::exists("hit_file_test_00000.h5"))
     {
-      boost::filesystem::remove("hit_file_test_00000.h5");
+      fs::remove("hit_file_test_00000.h5");
     }
   }
   void TearDown() override {}

--- a/src/modules/multigrid/mesytec/test/ReadoutTest.cpp
+++ b/src/modules/multigrid/mesytec/test/ReadoutTest.cpp
@@ -9,9 +9,9 @@ class MGHitTest : public TestBase {
 protected:
   void SetUp() override {
     hdf5::error::Singleton::instance().auto_print(false);
-    if (boost::filesystem::exists("hit_file_test_00000.h5"))
+    if (fs::exists("hit_file_test_00000.h5"))
     {
-      boost::filesystem::remove("hit_file_test_00000.h5");
+      fs::remove("hit_file_test_00000.h5");
     }
   }
   void TearDown() override {}


### PR DESCRIPTION
### Issue reference / description

Bump dependency versions were possible and get rid of boost.
Works on my machine (Ubuntu 20.04), let's see what happens on Jenkins.

Notably a big jump in librdkafka version from 0.11.5 -> 1.5.0

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
