### PR TITLE
update h5cpp version in conan file

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,7 +4,7 @@ cli11/1.9.1
 fmt/8.1.1
 graylog-logger/2.1.4-1@ess-dmsc/stable
 gtest/1.11.0
-h5cpp/0.4.0@ess-dmsc/stable
+h5cpp/0.5.2@ess-dmsc/stable
 nlohmann_json/3.10.5
 libpcap/1.10.1
 librdkafka/2.0.2

--- a/src/common/DumpFile.h
+++ b/src/common/DumpFile.h
@@ -80,7 +80,7 @@ private:
 
 template <typename T> DumpFile<T>::~DumpFile() {
   if (Data.size() && File.is_valid() &&
-      (File.intent() != hdf5::file::AccessFlags::READONLY)) {
+      (File.intent() != hdf5::file::AccessFlags::ReadOnly)) {
     flush();
   }
 }
@@ -122,15 +122,15 @@ boost::filesystem::path DumpFile<T>::get_full_path() const {
 template <typename T> void DumpFile<T>::openRW() {
   using namespace hdf5;
 
-  File = file::create(get_full_path(), file::AccessFlags::TRUNCATE);
+  File = file::create(get_full_path(), file::AccessFlags::Truncate);
 
   property::DatasetCreationList dcpl;
-  dcpl.layout(property::DatasetLayout::CHUNKED);
+  dcpl.layout(property::DatasetLayout::Chunked);
   dcpl.chunk({ChunkSize});
 
   DataSet = File.root().create_dataset(
       T::DatasetName(), DataType,
-      dataspace::Simple({0}, {dataspace::Simple::UNLIMITED}), dcpl);
+      dataspace::Simple({0}, {dataspace::Simple::unlimited}), dcpl);
   DataSet.attributes.create_from("format_version", T::FormatVersion());
   DataSet.attributes.create_from("EFU_version", efu_version());
   DataSet.attributes.create_from("EFU_build_string", efu_buildstr());
@@ -147,7 +147,7 @@ template <typename T> void DumpFile<T>::openR() {
   auto Path = PathBase;
   Path += ".h5";
 
-  File = file::open(Path, file::AccessFlags::READONLY);
+  File = file::open(Path, file::AccessFlags::ReadOnly);
   DataSet = File.root().get_dataset(T::DatasetName());
   // if not initial version, expect it to be well formed
   if (T::FormatVersion() > 0) {

--- a/src/common/readout/ess/ESSTimeTest.cpp
+++ b/src/common/readout/ess/ESSTimeTest.cpp
@@ -124,8 +124,10 @@ TEST_F(ESSTimeTest, Issue2021_11_08) {
   ASSERT_EQ(Time.TimeInNS - Time.PrevTimeInNS, 71428579);
 }
 
+} // namespace ESSReadout
+
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-} // namespace ESSReadout

--- a/src/common/readout/ess/ParserTest.cpp
+++ b/src/common/readout/ess/ParserTest.cpp
@@ -149,8 +149,9 @@ TEST_F(ReadoutTest, MaxPulseTimeError) {
   ASSERT_EQ(RdOut.Stats.ErrorTimeHigh, 1);
 }
 
+} // namespace ESSReadout
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-} // namespace ESSReadout

--- a/src/common/readout/vmm3/test/HybridTest.cpp
+++ b/src/common/readout/vmm3/test/HybridTest.cpp
@@ -33,8 +33,9 @@ TEST_F(HybridTest, IsAvailable) {
   ASSERT_FALSE(res);
 }
 
+} // namespace ESSReadout
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-} // namespace ESSReadout

--- a/src/common/readout/vmm3/test/VMM3ParserTest.cpp
+++ b/src/common/readout/vmm3/test/VMM3ParserTest.cpp
@@ -164,8 +164,9 @@ TEST_F(VMM3ParserTest, GoodCalib1) {
   ASSERT_EQ(VMMParser.Stats.CalibReadouts, 2);
 }
 
+} // namespace ESSReadout
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-} // namespace ESSReadout

--- a/src/common/reduction/test/HitTest.cpp
+++ b/src/common/reduction/test/HitTest.cpp
@@ -25,7 +25,7 @@ TEST_F(HitTest, CompoundMapping) {
   auto t = hdf5::datatype::create<Hit>();
 
   EXPECT_EQ(t.number_of_fields(), 4ul);
-  EXPECT_EQ(t.get_class(), hdf5::datatype::Class::COMPOUND);
+  EXPECT_EQ(t.get_class(), hdf5::datatype::Class::Compound);
 
   auto ct = hdf5::datatype::Compound(t);
 

--- a/src/common/test/FixedSizePoolTest.cpp
+++ b/src/common/test/FixedSizePoolTest.cpp
@@ -290,3 +290,8 @@ TEST_F(FixedSizePoolTest, Stats) {
 //    setBitIndex);
 //  }
 //}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/common/test/PoolAllocatorTest.cpp
+++ b/src/common/test/PoolAllocatorTest.cpp
@@ -110,3 +110,9 @@ TEST_F(PoolAllocatorTest, Share_2) {
   ASSERT_EQ(pool.NumSlotsUsed, 0);
   ASSERT_EQ(pool.ValidateEmptyStateAndReturnError(), nullptr);
 }
+
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/common/test/TestImageUdderTest.cpp
+++ b/src/common/test/TestImageUdderTest.cpp
@@ -55,3 +55,8 @@ TEST_F(TestImageUdderTest, CachePixelsWrap) {
   ASSERT_EQ(LastPixel, 123);
   ASSERT_EQ(FirstPixel, LastPixel);
 }
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/modules/ttlmonitor/test/ParserTest.cpp
+++ b/src/modules/ttlmonitor/test/ParserTest.cpp
@@ -133,9 +133,9 @@ TEST_F(TTLMonitorParserTest, DataGood) {
   ASSERT_EQ(parser.Stats.ErrorSize, 0);
   ASSERT_EQ(parser.Stats.Readouts, 2);
 }
+} // namespace TTLMonitor
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-} // namespace TTLMonitor


### PR DESCRIPTION
Older version of h5cpp requires special cmake flags to build properly on macos, newer version doesn't.

### Issue reference / description

The branch you merge from should already reference an event-formation-unit github ticket number. You can add a descriptive title, but if an issue is referenced, you don't have to.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
