### PR TITLE
Make macOS builds conditional on Jenkins var

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,8 +292,10 @@ timestamps {
             }
         }
 
-        // Add macOS pipeline to builders
-        builders['macOS'] = get_macos_pipeline()
+        if (env.ENABLE_MACOS_BUILDS.toUpperCase() == 'TRUE') {
+            // Add macOS pipeline to builders
+            builders['macOS'] = get_macos_pipeline()
+        }
 
         try {
             timeout(time: 2, unit: 'HOURS') {


### PR DESCRIPTION
### Issue reference / description

Make macOS builds conditional on Jenkins environment variable. This allows us to disable them globally as long as the Jenkinsfiles check the value of the variable, can be used as a temporary measure while we experience build issues on macOS, and also for a possible future transition (dropping/changing the builds).

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
