### PR TITLE
Add estia instrument

### DIFF
--- a/src/common/detector/BaseSettings.h
+++ b/src/common/detector/BaseSettings.h
@@ -32,6 +32,7 @@ struct BaseSettings {
   std::string   KafkaConfigFile      {""}; // use default
   std::string   KafkaBroker          {"localhost:9092"};
   std::string   KafkaTopic           {""};
+  std::string   KafkaDebugTopic      {""};
   ///\brief Graphite setting
   std::string   GraphitePrefix       {"efu.null"};
   std::string   GraphiteRegion       {"0"};

--- a/src/efu/MainProg.cpp
+++ b/src/efu/MainProg.cpp
@@ -23,8 +23,15 @@ MainProg::MainProg(std::string instrument, int argc, char *argv[]) {
   Args.printSettings();
   DetectorSettings = Args.getBaseSettings();
   DetectorSettings.DetectorName = instrument;
+
+  // If KafkaTopic is set via CLI use that topic and generate the _samples
+  // topic for the raw readout samples. Else use the default value
+
   if (DetectorSettings.KafkaTopic.empty()) {
     DetectorSettings.KafkaTopic = instrument + "_detector";
+    DetectorSettings.KafkaDebugTopic = instrument + "_detector_samples";
+  } else {
+    DetectorSettings.KafkaDebugTopic = DetectorSettings.KafkaTopic + "_samples";
   }
 
   graylog.AddLoghandlerForNetwork(

--- a/src/modules/freia/CMakeLists.txt
+++ b/src/modules/freia/CMakeLists.txt
@@ -31,6 +31,17 @@ set(freia_LIB efu_reduction efu_essreadout)
 create_executable(freia)
 
 
+
+
+set(estia_INC ${freia_common_inc})
+set(estia_SRC
+  ${freia_common_src}
+  main_estia.cpp
+  )
+set(estia_LIB efu_reduction efu_essreadout)
+create_executable(estia)
+
+
 ##
 ## FreiaiBaseTest Module integration test
 ##

--- a/src/modules/freia/FreiaBase.cpp
+++ b/src/modules/freia/FreiaBase.cpp
@@ -144,10 +144,7 @@ void FreiaBase::processing_thread() {
 
 
   // Event producer
-  if (EFUSettings.KafkaTopic == "") {
-    XTRACE(INIT, ALW, "Setting default Kafka topic to freia_detector");
-    EFUSettings.KafkaTopic = "freia_detector";
-  }
+  assert(EFUSettings.KafkaTopic != "");
 
   KafkaConfig KafkaCfg(EFUSettings.KafkaConfigFile);
   Producer eventprod(EFUSettings.KafkaBroker, EFUSettings.KafkaTopic,

--- a/src/modules/freia/main_estia.cpp
+++ b/src/modules/freia/main_estia.cpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2024 European Spallation Source, see LICENSE file
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Main entry for estia
+//===----------------------------------------------------------------------===//
+
+#include <efu/MainProg.h>
+#include <modules/freia/FreiaBase.h>
+
+int main(int argc, char *argv[]) {
+  MainProg Main("estia", argc, argv);
+
+  auto Detector = new Freia::FreiaBase(Main.DetectorSettings);
+
+  return Main.run(Detector);
+}

--- a/src/modules/freia/test/FreiaBaseTest.cpp
+++ b/src/modules/freia/test/FreiaBaseTest.cpp
@@ -48,6 +48,7 @@ public:
 
   void SetUp() override {
     Settings.ConfigFile = FREIA_FULL;
+    Settings.KafkaTopic = "freia_detector";
     Settings.RxSocketBufferSize = 100000;
     Settings.NoHwCheck = true;
   }


### PR DESCRIPTION
Along the lines of the caen based instrument we add a estia executable which is essentially a freia instrument but with different Kafka topics and possibly, but not yet implemented, a different channel mapping.

For no I just want the EFU up and running at YMIR. Hence the PR.