### PR TITLE
Ecdc 3760 mac build broken by compiler warning option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,28 @@ set(EFU_COMMON_LIBS
 
 set(EFU_COMMON_LIBS ${EFU_COMMON_LIBS} PARENT_SCOPE)
 
+#=============================================================================
+# Identify the Linux distribution
+#=============================================================================
+
+# Add CentOS-specific configuration here
+set(REDHAT_RELEASE_FILE "/etc/redhat-release")
+set(UBUNTU_RELEASE_FILE "/etc/lsb-release")
+set(ALMA_LINUX_RELEASE_FILE "/etc/alma-release")
+
+if(EXISTS ${REDHAT_RELEASE_FILE})
+  execute_process(COMMAND cat ${REDHAT_RELEASE_FILE}
+          OUTPUT_VARIABLE LINUX_DISTRIBUTION
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+elseif(EXISTS ${UBUNTU_RELEASE_FILE})
+  execute_process(COMMAND cat ${UBUNTU_RELEASE_FILE}
+          OUTPUT_VARIABLE LINUX_DISTRIBUTION
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+elseif(EXISTS ${ALMA_LINUX_RELEASE_FILE})
+  execute_process(COMMAND cat ${ALMA_LINUX_RELEASE_FILE}
+          OUTPUT_VARIABLE LINUX_DISTRIBUTION
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
 #=============================================================================
 # Include subdirs, do not change order

--- a/src/modules/timepix3/CMakeLists.txt
+++ b/src/modules/timepix3/CMakeLists.txt
@@ -90,7 +90,23 @@ create_test_executable(Timepix3TimingEventHandlerTest)
 set(Timepix3PixelEventHandlerTest_INC
   ${timepix3_common_inc}
 )
-add_compile_options(-Wno-maybe-uninitialized)
+
+# Add CentOS-specific configuration here
+set(RELEASE_FILE "/etc/redhat-release")
+
+if(EXISTS ${RELEASE_FILE})
+    execute_process(COMMAND cat ${RELEASE_FILE}
+                    OUTPUT_VARIABLE LINUX_DISTRIBUTION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    # Workaround for CentOS 7 gcc for mockups in tests
+    if (LINUX_DISTRIBUTION MATCHES "CentOS")
+        message(STATUS "CentOS detected enable -Wno-maybe-uninitialized 
+        for Timepix3PixelEventHandlerTest")
+        add_compile_options(-Wno-maybe-uninitialized)
+    endif()
+endif()
+
 set(Timepix3PixelEventHandlerTest_SRC
   ${timepix3_common_src}
   test/Timepix3PixelEventHandlerTest.cpp

--- a/src/modules/timepix3/CMakeLists.txt
+++ b/src/modules/timepix3/CMakeLists.txt
@@ -91,20 +91,11 @@ set(Timepix3PixelEventHandlerTest_INC
   ${timepix3_common_inc}
 )
 
-# Add CentOS-specific configuration here
-set(RELEASE_FILE "/etc/redhat-release")
-
-if(EXISTS ${RELEASE_FILE})
-    execute_process(COMMAND cat ${RELEASE_FILE}
-                    OUTPUT_VARIABLE LINUX_DISTRIBUTION
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    # Workaround for CentOS 7 gcc for mockups in tests
-    if (LINUX_DISTRIBUTION MATCHES "CentOS")
-        message(STATUS "CentOS detected enable -Wno-maybe-uninitialized 
-        for Timepix3PixelEventHandlerTest")
-        add_compile_options(-Wno-maybe-uninitialized)
-    endif()
+# Workaround for old gcc in CentOS 7 for mockups in tests
+if (LINUX_DISTRIBUTION MATCHES "CentOS")
+    message(STATUS "CentOS detected enable -Wno-maybe-uninitialized 
+    for Timepix3PixelEventHandlerTest")
+    add_compile_options(-Wno-maybe-uninitialized)
 endif()
 
 set(Timepix3PixelEventHandlerTest_SRC


### PR DESCRIPTION
### Issue reference / description

The branch you merge from should already reference an event-formation-unit github ticket number. You can add a descriptive title, but if an issue is referenced, you don't have to.

## Checklist for submitter

- [x] Check for conflict with integration test
- [x] Unit tests pass

---

### Nominate for Group Code Review

- [x] Nominate for code review
