### PR TITLE
Fix wrong header generatedtype for v0 header

### DIFF
--- a/src/generators/essudpgen/ReadoutGeneratorBase.cpp
+++ b/src/generators/essudpgen/ReadoutGeneratorBase.cpp
@@ -80,11 +80,7 @@ void ReadoutGeneratorBase::generateHeader() {
   }
 
   memset(Buffer, 0, BufferSize);
-  auto Header = reinterpret_cast<Parser::PacketHeaderV1 *>(Buffer);
-
-  if (headerVersion == Parser::HeaderVersion::V1) {
-    Header = reinterpret_cast<Parser::PacketHeaderV1 *>(Buffer);
-  }
+  auto Header = reinterpret_cast<Parser::PacketHeaderV0 *>(Buffer);
 
   Header->CookieAndType = (Settings.Type << 24) + 0x535345;
   Header->Padding0 = 0;
@@ -107,7 +103,8 @@ void ReadoutGeneratorBase::generateHeader() {
   Header->PrevPulseLow = PrevTimeLowOffset;
 
   if (headerVersion == Parser::HeaderVersion::V1) {
-    Header->CMACPadd = 0;
+    auto HeaderV1 = reinterpret_cast<Parser::PacketHeaderV1 *>(Buffer);
+    HeaderV1->CMACPadd = 0;
   }
 
   XTRACE(DATA, DEB, "new packet header, time high %u, time low %u", TimeHigh,


### PR DESCRIPTION
### Issue reference / description

This is a patch to correct a bug in generator base, creating incorrect types in case of v0 header generated.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
