### PR TITLE
Re-add addEvent call removed by mistake

### DIFF
--- a/src/modules/freia/FreiaInstrument.cpp
+++ b/src/modules/freia/FreiaInstrument.cpp
@@ -255,6 +255,7 @@ void FreiaInstrument::generateEvents(std::vector<Event> &Events) {
 
     XTRACE(EVENT, INF, "Time: %u TOF: %u, x %u, y %u, pixel %u", time,
            TimeOfFlight, x, y, PixelId);
+    Serializer->addEvent(TimeOfFlight, PixelId);
     counters.Events++;
   }
   Events.clear(); // else events will accumulate


### PR DESCRIPTION
### Issue reference / description

I removed the call by mistake when removing the `TxBytes`/`transmit.bytes` stat and metric.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
