### PR TITLE
Update Kafka topic for CAEN AR51 messages

### DIFF
--- a/src/modules/caen/CaenBase.cpp
+++ b/src/modules/caen/CaenBase.cpp
@@ -159,7 +159,7 @@ void CaenBase::processingThread() {
     EventProducerII.produce(DataBuffer, Timestamp);
   };
 
-  Producer MonitorProducer(EFUSettings.KafkaBroker, "nmx_debug",
+  Producer MonitorProducer(EFUSettings.KafkaBroker, EFUSettings.KafkaDebugTopic,
                            KafkaCfg.CfgParms);
   auto ProduceMonitor = [&MonitorProducer](auto DataBuffer, auto Timestamp) {
     MonitorProducer.produce(DataBuffer, Timestamp);
@@ -169,7 +169,7 @@ void CaenBase::processingThread() {
   Caen.setSerializerII(
       SerializerII); // would rather have this in CaenInstrument
 
-  MonitorSerializer = new AR51Serializer("caen", ProduceMonitor);
+  MonitorSerializer = new AR51Serializer(EFUSettings.DetectorName, ProduceMonitor);
 
   unsigned int DataIndex;
   TSCTimer ProduceTimer(EFUSettings.UpdateIntervalSec * 1000000 * TSC_MHZ);


### PR DESCRIPTION
The ECDC Kafka topic name specification states that raw detector readouts should be published on a stream with topic name `{instrument}_detector_samples`, but `nmx_debug` was hard coded for the `MonitorProducer`. The correct topic name is already constructed and saved as `EFUSettings.KafkaDebugTopic`.  This commit changes the `MonitorProducer` for CAEN-based modules to use the correct topic name, and updates the `MonitorSerializer` to use the `EFUSettings.DetectorName` as `Source`.

### Issue reference / description

The branch you merge from should already reference an event-formation-unit github ticket number. You can add a descriptive title, but if an issue is referenced, you don't have to.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

### Nominate for Group Code Review

- [x] Nominate for code review
