### PR TITLE
[Remove] install target [Add] allefus and copylibs targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ elseif(NOT ${CONAN} MATCHES "DISABLE")
   MESSAGE(FATAL_ERROR "Unrecognised option for CONAN (${CONAN}), use AUTO, MANUAL or DISABLE")
 endif()
 
+# Copy libraries to build directory
+add_custom_target(copylibs COMMAND conan imports ${CMAKE_SOURCE_DIR}/conanfile.txt -imf ${PROJECT_BINARY_DIR})
+
 #=============================================================================
 # General configuration
 #=============================================================================

--- a/cmake/BuildFunctions.cmake
+++ b/cmake/BuildFunctions.cmake
@@ -37,7 +37,6 @@ function(create_module module_name)
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/modules")
 
   enable_coverage(${module_name})
-  install(TARGETS ${module_name} DESTINATION bin)
 endfunction(create_module)
 
 #=============================================================================
@@ -61,7 +60,6 @@ function(create_executable exec_name)
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
   enable_coverage(${exec_name})
-  install(TARGETS ${exec_name} DESTINATION bin)
 endfunction(create_executable)
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,8 @@ add_custom_target(copycfgs
     COMMENT "Copying json configuration files to ${PROJECT_BINARY_DIR}/configs"
 )
 
+add_custom_target(allefus DEPENDS dream loki bifrost miracles freia trex cbm nmx cspec timepix3)
+
 add_custom_target(runefu
     COMMAND loki     "-f" "../configs/LokiFull.json" "--calibration" "../configs/lokinullcalib.json"     "-s" "1" "--nohwcheck" "--dumptofile" "deleteme_"
     COMMAND bifrost  "-f" "../configs/bifrost.json"    "--calibration" "../configs/bifrostnullcalib.json"  "-s" "2" "--nohwcheck" "--dumptofile" "deleteme_user.h5"
@@ -117,5 +119,5 @@ add_custom_target(runefu
     COMMAND cbm      "-f" "../configs/freiamon.json" "-s" "2" "--nohwcheck" "--dumptofile" "deleteme_ttlmon_" "-t" "freia_beam_monitor"
     COMMAND nmx      "-f" "../configs/nmx.json" "-s" "2"  "--nohwcheck"
     COMMAND timepix3 "-f" "../configs/timepix3.json" "-s" "2" "--nohwcheck"
-    DEPENDS copycfgs dream loki bifrost miracles freia trex cbm nmx cspec timepix3
+    DEPENDS copycfgs allefus
     )


### PR DESCRIPTION
### Issue #732 

Implements the alternate fix for #732 by removing the `install` CMake target, adding a single `allefus` target (to allow building just the EFU binaries in parallel) and a `copylibs` target that invokes `conan imports` to copy library files into the build directory.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
