### PR TITLE
[Add] upper pulse height threshold configuration for CAEN modules, and check in BIFROST geometry

### DIFF
--- a/src/modules/bifrost/configs/bifrost.json
+++ b/src/modules/bifrost/configs/bifrost.json
@@ -3,5 +3,5 @@
   "MaxRing": 4,
   "StrawResolution": 300,
   "MaxGroup": 15,
-  "MaxAmpl": 32768
+  "MaxAmpl": 32767
 }

--- a/src/modules/bifrost/configs/bifrost.json
+++ b/src/modules/bifrost/configs/bifrost.json
@@ -2,5 +2,6 @@
   "Detector": "bifrost",
   "MaxRing": 4,
   "StrawResolution": 300,
-  "MaxGroup": 15
+  "MaxGroup": 15,
+  "MaxAmpl": 32768
 }

--- a/src/modules/bifrost/geometry/BifrostGeometry.cpp
+++ b/src/modules/bifrost/geometry/BifrostGeometry.cpp
@@ -64,13 +64,16 @@ int BifrostGeometry::yOffset(int Group) {
 
 std::pair<int, double> BifrostGeometry::calcUnitAndPos(int Group, int AmpA,
                                                        int AmpB) {
-  if (int pulse_height = AmpA + AmpB; 0 == pulse_height || pulse_height > MaxAmpl){
-    XTRACE(DATA, DEB, (pulse_height ? "Sum of amplitudes exceeds maximum" : "Sum of amplitudes is zero"));
-    if (pulse_height) {
-      Stats.AmplitudeHigh++;
-    } else {
-      Stats.AmplitudeZero++;
-    }
+
+  if (AmpA + AmpB == 0) {
+    XTRACE(DATA, DEB, "Sum of amplitudes is 0");
+    Stats.AmplitudeZero++;
+    return InvalidPos;
+  }
+
+  if (AmpA + AmpB > MaxAmpl){
+    XTRACE(DATA, DEB, "Sum of amplitudes exceeds maximum");
+    Stats.AmplitudeHigh++;
     return InvalidPos;
   }
 

--- a/src/modules/bifrost/geometry/BifrostGeometry.cpp
+++ b/src/modules/bifrost/geometry/BifrostGeometry.cpp
@@ -22,6 +22,7 @@ namespace Caen {
   MaxRing = CaenConfiguration.Legacy.MaxRing;
   MaxFEN = CaenConfiguration.Legacy.MaxFEN;
   MaxGroup = CaenConfiguration.Legacy.MaxGroup;
+  MaxAmpl = CaenConfiguration.Legacy.MaxAmpl;
 }
 
 bool BifrostGeometry::validateData(DataParser::CaenReadout &Data) {
@@ -63,10 +64,13 @@ int BifrostGeometry::yOffset(int Group) {
 
 std::pair<int, double> BifrostGeometry::calcUnitAndPos(int Group, int AmpA,
                                                        int AmpB) {
-
-  if (AmpA + AmpB == 0) {
-    XTRACE(DATA, DEB, "Sum of amplitudes is 0");
-    Stats.AmplitudeZero++;
+  if (int pulse_height = AmpA + AmpB; 0 == pulse_height || pulse_height > MaxAmpl){
+    XTRACE(DATA, DEB, (pulse_height ? "Sum of amplitudes exceeds maximum" : "Sum of amplitudes is zero"));
+    if (pulse_height) {
+      Stats.AmplitudeHigh++;
+    } else {
+      Stats.AmplitudeZero++;
+    }
     return InvalidPos;
   }
 

--- a/src/modules/bifrost/test/BifrostGeometryTest.cpp
+++ b/src/modules/bifrost/test/BifrostGeometryTest.cpp
@@ -38,6 +38,9 @@ protected:
           {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}});
     }
     geom->CaenCDCalibration.Intervals[ManualCalibGroup] = ManualCalib;
+
+    // force the half-range upper limit on pulse-height values
+    geom->MaxAmpl = 32768;
   }
   void TearDown() override {}
 };
@@ -90,6 +93,14 @@ TEST_F(BifrostGeometryTest, PosOutsideInterval) {
 TEST_F(BifrostGeometryTest, BadAmplitudes) {
   // A = -1, B = 20 -> pos < 0
   std::pair<int, float> Result = geom->calcUnitAndPos(ManualCalibGroup, -1, 20);
+  ASSERT_EQ(Result.first, -1);
+}
+
+TEST_F(BifrostGeometryTest, TooLargeAmplitudes){
+  // A + B > 32768  -> pos < 0
+  auto Result = geom->calcUnitAndPos(ManualCalibGroup, 32768, 1);
+  ASSERT_EQ(Result.first, -1);
+  Result = geom->calcUnitAndPos(ManualCalibGroup, 1, 32768);
   ASSERT_EQ(Result.first, -1);
 }
 

--- a/src/modules/bifrost/test/BifrostGeometryTest.cpp
+++ b/src/modules/bifrost/test/BifrostGeometryTest.cpp
@@ -40,7 +40,7 @@ protected:
     geom->CaenCDCalibration.Intervals[ManualCalibGroup] = ManualCalib;
 
     // force the half-range upper limit on pulse-height values
-    geom->MaxAmpl = 32768;
+    geom->MaxAmpl = 32767;
   }
   void TearDown() override {}
 };
@@ -98,9 +98,13 @@ TEST_F(BifrostGeometryTest, BadAmplitudes) {
 
 TEST_F(BifrostGeometryTest, TooLargeAmplitudes){
   // A + B > 32768  -> pos < 0
-  auto Result = geom->calcUnitAndPos(ManualCalibGroup, 32768, 1);
+  auto Result = geom->calcUnitAndPos(ManualCalibGroup, 32767, 1);
   ASSERT_EQ(Result.first, -1);
-  Result = geom->calcUnitAndPos(ManualCalibGroup, 1, 32768);
+  Result = geom->calcUnitAndPos(ManualCalibGroup, 1, 32767);
+  ASSERT_EQ(Result.first, -1);
+  Result = geom->calcUnitAndPos(ManualCalibGroup, 0, 32768);
+  ASSERT_EQ(Result.first, -1);
+  Result = geom->calcUnitAndPos(ManualCalibGroup, 32768, 0);
   ASSERT_EQ(Result.first, -1);
 }
 

--- a/src/modules/caen/CaenBase.cpp
+++ b/src/modules/caen/CaenBase.cpp
@@ -84,6 +84,7 @@ CaenBase::CaenBase(BaseSettings const &settings,
   Stats.create("geometry.group_errors", Counters.Geom.GroupErrors);
   Stats.create("geometry.ampl_zero", Counters.Geom.AmplitudeZero);
   Stats.create("geometry.ampl_low", Counters.Geom.AmplitudeLow);
+  Stats.create("geometry.ampl_high", Counters.Geom.AmplitudeHigh);
   Stats.create("geometry.pos_low", Counters.Calibration.ClampLow);
   Stats.create("geometry.pos_high", Counters.Calibration.ClampHigh);
   Stats.create("geometry.calib_group_errors", Counters.Calibration.GroupErrors);

--- a/src/modules/caen/geometry/Config.cpp
+++ b/src/modules/caen/geometry/Config.cpp
@@ -87,6 +87,14 @@ void Config::parseConfig() {
       XTRACE(INIT, DEB, "MaxFEN: %u", Legacy.MaxFEN);
 
       try {
+        Legacy.MaxAmpl = root["MaxAmpl"].get<int>();
+      } catch (...) {
+        // Use default (maximum for integer type) value
+      }
+      LOG(INIT, Sev::Info, "MaxAmpl: {}", Legacy.MaxAmpl);
+      XTRACE(INIT, DEB, "MaxAmpl: %u", Legacy.MaxAmpl);
+
+      try {
         Legacy.MaxGroup = root["MaxGroup"].get<unsigned int>();
       } catch (...) {
         // Use default value

--- a/src/modules/caen/geometry/Config.h
+++ b/src/modules/caen/geometry/Config.h
@@ -43,6 +43,7 @@ public:
     uint8_t MaxRing{0};
     uint8_t MaxFEN{0};
     uint8_t MaxGroup{14};
+    int MaxAmpl{(std::numeric_limits<int>::max)()};
 } Legacy;
 
   LokiConfig LokiConf;

--- a/src/modules/caen/geometry/Geometry.h
+++ b/src/modules/caen/geometry/Geometry.h
@@ -60,6 +60,7 @@ public:
     int64_t GroupErrors{0};
     int64_t AmplitudeZero{0};
     int64_t AmplitudeLow{0};
+    int64_t AmplitudeHigh{0};
   } Stats;
 
   CDCalibration CaenCDCalibration;
@@ -69,5 +70,6 @@ public:
   uint8_t MaxFEN{0};
   uint8_t MaxGroup{0};
   int MinAmpl{0};
+  int MaxAmpl{(std::numeric_limits<int>::max)()};
 };
 } // namespace Caen


### PR DESCRIPTION
# The total pulse height for valid charge-division events should not exceed the maximum ADC value for any of its signals
## Problem
If a charge-division detector is correctly configured, the maximum total pulse height (A + B + ...) of a real event should never exceed the maximum output-value of the ADC for _one_ channel. If this is not true, then position reconstruction is lost near the values where any one of (A, B, ...) nears its maximum.

Spurious events, however, may produce total pulse heights in excess of this threshold. If present, such events are not isolated in the charge-divided space, so they must be removed based on total pulse height to avoid unwanted contamination.

## Solution
This PR adds a configuration key for CAEN based detectors to specify the maximum allowable pulse height value. If not specified the maximum `int` value is used.

At present, only the BIFROST module is modified to make use of this new configuration key. If A+B exceeds 2<sup>15</sup> a new statistic counter is incremented and the invalid pixel position is returned.

## Conclusion
A new configuration-file key can be used to identify the maximum single-channel ADC value.
This is then used by the BIFROST module to exclude too-large spurious signals.

This solution can be extended to the other CAEN based instruments, with a possibly-different maximum ADC value.

---

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
