### PR TITLE
Missing <cstdint> includes required for Ubuntu 24.04.1 LTS

### DIFF
--- a/src/modules/cbm/CbmTypes.h
+++ b/src/modules/cbm/CbmTypes.h
@@ -10,7 +10,7 @@
 #pragma once
 
 
-
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 

--- a/src/modules/nmx/geometry/Geometry.h
+++ b/src/modules/nmx/geometry/Geometry.h
@@ -12,6 +12,7 @@
 
 #include <common/debug/Trace.h>
 
+#include <cstdint>
 #include <string>
 #include <utility>
 

--- a/src/modules/trex/geometry/Geometry.h
+++ b/src/modules/trex/geometry/Geometry.h
@@ -12,6 +12,7 @@
 
 #include <common/debug/Trace.h>
 
+#include <cstdint>
 #include <string>
 #include <utility>
 


### PR DESCRIPTION
### Issue reference / description

The EFU component cannot build on Ubuntu 24.04 due to missing includes of `<cstdint>`

```
/home/mpi/ESS/event-formation-unit/src/modules/./trex/geometry/Geometry.h:17:1: 
note: ‘uint16_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
```

The missing includes are added in this PR

- [x] Check for conflict with integration test
- [x] Unit tests pass

---

### Nominate for Group Code Review

- [x] Nominate for code review
