### PR TITLE
Update DreamGeometry.cpp

### DIFF
--- a/src/modules/dream/geometry/Cuboid.h
+++ b/src/modules/dream/geometry/Cuboid.h
@@ -119,20 +119,20 @@ public:
     if (Parms.Type == Config::ModuleType::SANS) {
       if (Index >= (int)OffsetsSANS.size()) {
         XTRACE(DATA, WAR, "Bad SANS index %u", Index);
-        return -1;
+        return 0;
       }
       Offset = OffsetsSANS[Index];
       Rotation = RotateSANS[Index];
     } else if (Parms.Type == Config::ModuleType::HR) {
       if (Index >= (int)OffsetsHR.size()) {
         XTRACE(DATA, WAR, "Bad HR index %u", Index);
-        return -1;
+        return 0;
       }
       Offset = OffsetsHR[Index];
       Rotation = RotateHR[Index];
     } else {
       XTRACE(DATA, WAR, "Inconsistent type (%d) for Cuboid", Parms.Type);
-      return -1;
+      return 0;
     }
 
     int LocalX = 2 * Cassette + Counter; // unrotated x,y values

--- a/src/modules/dream/geometry/DreamGeometry.cpp
+++ b/src/modules/dream/geometry/DreamGeometry.cpp
@@ -43,8 +43,8 @@ int DreamGeometry::getPixel(Config::ModuleParms &Parms,
     break;
   }
 
-  if (Pixel == 0) {
-    XTRACE(DATA, WAR, "Invalid pixel returned");
+  if (Pixel < 1) {
+    XTRACE(DATA, WAR, "Invalid pixel returned: %d", Pixel);
     return 0;
   }
 

--- a/src/modules/dream/test/CuboidTest.cpp
+++ b/src/modules/dream/test/CuboidTest.cpp
@@ -69,19 +69,19 @@ TEST_F(CuboidGeometryTest, Rotate3) {
 
 TEST_F(CuboidGeometryTest, OffsetRange) {
   Parms.P1.Index = 32;
-  ASSERT_NE(geometry.getPixelId(Parms, Readout), -1);
+  ASSERT_NE(geometry.getPixelId(Parms, Readout), 0);
   Parms.P1.Index = 33;
-  ASSERT_EQ(geometry.getPixelId(Parms, Readout), -1);
+  ASSERT_EQ(geometry.getPixelId(Parms, Readout), 0);
 
   Parms.Type = Config::ModuleType::SANS;
   Parms.P1.Index = 35;
-  ASSERT_NE(geometry.getPixelId(Parms, Readout), -1);
+  ASSERT_NE(geometry.getPixelId(Parms, Readout), 0);
   Parms.P1.Index = 36;
-  ASSERT_EQ(geometry.getPixelId(Parms, Readout), -1);
+  ASSERT_EQ(geometry.getPixelId(Parms, Readout), 0);
 
   Parms.Type = Config::ModuleType::FwEndCap;
   Parms.P1.Index = 0;
-  ASSERT_EQ(geometry.getPixelId(Parms, Readout), -1);
+  ASSERT_EQ(geometry.getPixelId(Parms, Readout), 0);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Ensure pixels returned by lookup are positive

### Issue reference / description
This is a continuation of a fix for https://jira.ess.eu/browse/ECDC-4373 but fixing the offset for HR detectors

`cuboid.h:102:getPixelId` returns `-1` if there is some error looking up the pixel, which is then not caught for the final pixel generated, since it is assumed to be valid and then added to an offset, resulting in a final pixel value greater than 1 and therefore processed as valid

By adjusting the check from `0` to checking for a `pixel < 1`, we check for errors not just from the modules already fixed, but any others in future too.

This could also be fixed by returning `0` instead of `-1` in cuboid.h

## Checklist for submitter

- [ x ] Check for conflict with integration test
- [ x ] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
