### PR TITLE
updated warning and logic

### DIFF
--- a/src/modules/dream/geometry/DreamGeometry.cpp
+++ b/src/modules/dream/geometry/DreamGeometry.cpp
@@ -43,13 +43,14 @@ int DreamGeometry::getPixel(Config::ModuleParms &Parms,
     break;
   }
 
-  if (Pixel < 1) {
-    XTRACE(DATA, WAR, "Invalid pixel returned: %d", Pixel);
+  if (Pixel == 0) {
+    XTRACE(DATA, WAR, "Invalid pixel returned in module: %i", Parms.Type);
     return 0;
   }
 
   int Offset = getPixelOffset(Parms.Type);
   if (Offset == -1) {
+    XTRACE(DATA, WAR, "No offset given for module %i", Parms.Type);
     return 0;
   }
   int GlobalPixel = Offset + Pixel;


### PR DESCRIPTION
### Issue reference / description

ECDC-4373 introduced a fix for misreported pixels.  This reverts some logic in that PR, informing the user only if the pixel returned is zero.

An error message was also added for the pixel offset, which previously failed silently.

## Checklist for submitter

- [ x ] Check for conflict with integration test
- [ x ] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
