### PR TITLE
ECDC-4519: Clean up std::string in the EFU package

### DIFF
--- a/src/common/JsonFile.h
+++ b/src/common/JsonFile.h
@@ -45,7 +45,7 @@ inline void json_change_key(nlohmann::json &object, const std::string& old_key, 
 
 /// \brief Given a nlohmann json object and a list of known required fields
 /// return a string with the missing fields.
-inline void json_check_keys(std::string Prefix, nlohmann::json &object,
+inline void json_check_keys(const std::string &Prefix, nlohmann::json &object,
   std::vector<std::string> RequiredFields) {
   std::string Missing{""};
 

--- a/src/common/StatPublisher.cpp
+++ b/src/common/StatPublisher.cpp
@@ -11,7 +11,7 @@
 #include <fmt/format.h>
 
 ///
-StatPublisher::StatPublisher(std::string IP, int Port)
+StatPublisher::StatPublisher(const std::string &IP, int Port)
     : IpAddress(IP), TCPPort(Port) {
   if (not Socket::isValidIp(IpAddress)) {
     IpAddress = Socket::getHostByName(IpAddress);

--- a/src/common/StatPublisher.h
+++ b/src/common/StatPublisher.h
@@ -19,7 +19,7 @@ class StatPublisher {
 public:
   /// \brief Connect to a Carbon/Graphite server by ip address/hostname and tcp
   /// port
-  StatPublisher(std::string IP, int Port);
+  StatPublisher(const std::string &IP, int Port);
 
   /// \brief Send detector metrics to Carbon/Graphite server given additional
   /// stats

--- a/src/common/Statistics.cpp
+++ b/src/common/Statistics.cpp
@@ -10,7 +10,7 @@
 #include <common/Statistics.h>
 #include <common/debug/Log.h>
 
-int Statistics::create(std::string StatName, int64_t &Value) {
+int Statistics::create(const std::string &StatName, int64_t &Value) {
   LOG(UTILS, Sev::Info, "Adding stat {}", StatName);
   Value = 0; // all counters are cleared
   auto FullStatName = prefix + StatName;
@@ -41,7 +41,7 @@ int64_t Statistics::value(size_t Index) {
   return stats.at(Index - 1).StatValue;
 }
 
-int64_t Statistics::valueByName(std::string name) {
+int64_t Statistics::valueByName(const std::string &name) {
   for (const auto &stat : stats) {
     if (stat.StatName.find(name) != std::string::npos) {
       return stat.StatValue;
@@ -50,7 +50,7 @@ int64_t Statistics::valueByName(std::string name) {
   return -1;
 }
 
-void Statistics::setPrefix(std::string StatsPrefix, std::string StatsRegion) {
+void Statistics::setPrefix(const std::string &StatsPrefix, const std::string &StatsRegion) {
   if (StatsPrefix.size() > 0) {
     prefix = StatsPrefix;
     const char LastChar = StatsPrefix.back();

--- a/src/common/Statistics.h
+++ b/src/common/Statistics.h
@@ -17,7 +17,7 @@
 class StatTuple {
 public:
   /// \brief holds a name, value pair defining a 'stat'
-  StatTuple(std::string Name, const int64_t &Value)
+  StatTuple(const std::string &Name, const int64_t &Value)
       : StatName(Name), StatValue(Value){};
   std::string StatName;
   const int64_t &StatValue;
@@ -33,7 +33,7 @@ public:
 
   /// \brief creates a 'stat' entry with name and address for counter
   /// duplicates are not allowed.
-  int create(std::string StatName, int64_t &Value);
+  int create(const std::string &StatName, int64_t &Value);
 
   /// \brief returns the number of registered stats
   size_t size();
@@ -45,11 +45,11 @@ public:
   int64_t value(size_t Index);
 
   /// \brief return value by name
-  int64_t valueByName(std::string name);
+  int64_t valueByName(const std::string &name);
 
   /// \brief create grafana metric prefix by concatenation of strings
   /// PointChar will be added to the end
-  void setPrefix(std::string StatsPrefix, std::string StatsRegion);
+  void setPrefix(const std::string &StatsPrefix, const std::string &StatsRegion);
 
 private:
   std::string prefix{""};       ///< prepend to all stat names

--- a/src/common/detector/Detector.h
+++ b/src/common/detector/Detector.h
@@ -113,7 +113,7 @@ public:
 
   /// \brief returns the value of a runtime counter (efustat) based on name
   /// used by Parser.cpp for command query
-  virtual int64_t statvaluebyname(std::string name) {
+  virtual int64_t statvaluebyname(const std::string &name) {
     return Stats.valueByName(name);
   }
 
@@ -168,7 +168,7 @@ public:
     Threads.emplace_back(ThreadInfo{func, std::move(funcName), std::thread()});
   };
 
-  void AddCommandFunction(std::string Name, CommandFunction FunctionObj) {
+  void AddCommandFunction(const std::string &Name, CommandFunction FunctionObj) {
     DetectorCommands[Name] = FunctionObj;
   };
 

--- a/src/common/detector/EFUArgs.cpp
+++ b/src/common/detector/EFUArgs.cpp
@@ -41,7 +41,7 @@ EFUArgs::EFUArgs() {
   CLIParser.add_option("--kafka_config", EFUSettings.KafkaConfigFile, "Kafka configuration file")
       ->group("EFU Options")->default_str("");
 
-  CLIParser.add_option("-l,--log_level", [this](std::vector<std::string> Input) {
+  CLIParser.add_option("-l,--log_level", [this](const std::vector<std::string> &Input) {
     return parseLogLevel(Input);
   }, "Set log message level. Set to 1 - 7 or one of \n                              `Critical`, `Error`, `Warning`, `Notice`, `Info`,\n                              or `Debug`. Ex: \"-l Notice\"")
   ->group("EFU Options")->default_str("Info");
@@ -140,7 +140,7 @@ EFUArgs::EFUArgs() {
   // clang-format on
 }
 
-bool EFUArgs::parseLogLevel(std::vector<std::string> LogLevelString) {
+bool EFUArgs::parseLogLevel(const std::vector<std::string> &LogLevelString) {
   std::map<std::string, int> LevelMap{{"Critical", 2}, {"Error", 3},
                                       {"Warning", 4},  {"Notice", 5},
                                       {"Info", 6},     {"Debug", 7}};

--- a/src/common/detector/EFUArgs.h
+++ b/src/common/detector/EFUArgs.h
@@ -44,7 +44,7 @@ public:
   int buflen{9000}; ///< rx buffer length (B)
 
 private:
-  bool parseLogLevel(std::vector<std::string> LogLevelString);
+  bool parseLogLevel(const std::vector<std::string> &LogLevelString);
   int LogMessageLevel{6};
   std::string DetectorName;
   std::string LogFileName;

--- a/src/common/kafka/AR51Serializer.cpp
+++ b/src/common/kafka/AR51Serializer.cpp
@@ -20,7 +20,7 @@ static_assert(FLATBUFFERS_LITTLEENDIAN,
 
 
 AR51Serializer::AR51Serializer(
-    std::string SourceName, ProducerCallback Callback) :
+    const std::string &SourceName, ProducerCallback Callback) :
     Source(SourceName), ProduceFunctor(Callback) {
 }
 

--- a/src/common/kafka/AR51Serializer.h
+++ b/src/common/kafka/AR51Serializer.h
@@ -19,7 +19,7 @@ public:
   /// \brief creates ar51 flat buffer serializer
   /// \param source_name value for source_name field
   /// \param Callback
-  AR51Serializer(std::string SourceName, ProducerCallback Callback = {});
+  AR51Serializer(const std::string &SourceName, ProducerCallback Callback = {});
 
   /// \brief adds event, if maximum count is exceeded, sends data using the
   /// producer callback \param time time of event in relation to pulse time

--- a/src/common/kafka/EV44Serializer.cpp
+++ b/src/common/kafka/EV44Serializer.cpp
@@ -36,7 +36,7 @@ static constexpr int64_t FBMutablePlaceholder = 1;
 static_assert(FLATBUFFERS_LITTLEENDIAN,
               "Flatbuffers only tested on little endian systems");
 
-EV44Serializer::EV44Serializer(size_t MaxArrayLength, std::string SourceName,
+EV44Serializer::EV44Serializer(size_t MaxArrayLength, const std::string &SourceName,
                                ProducerCallback Callback)
     : MaxEvents(MaxArrayLength), Builder_(MaxEvents * 8 + 256),
       ProduceFunctor(Callback), Stats() {

--- a/src/common/kafka/EV44Serializer.h
+++ b/src/common/kafka/EV44Serializer.h
@@ -33,7 +33,7 @@ public:
   /// \brief creates ev44 flat buffer serializer
   /// \param max_array_length maximum number of events
   /// \param source_name value for source_name field
-  EV44Serializer(size_t MaxArrayLength, std::string SourceName,
+  EV44Serializer(size_t MaxArrayLength, const std::string &SourceName,
                  ProducerCallback Callback = {});
 
   virtual ~EV44Serializer() = default;

--- a/src/common/kafka/KafkaConfig.cpp
+++ b/src/common/kafka/KafkaConfig.cpp
@@ -14,7 +14,7 @@
 // #undef TRC_LEVEL
 // #define TRC_LEVEL TRC_L_DEB
 
-KafkaConfig::KafkaConfig(std::string KafkaConfigFile) {
+KafkaConfig::KafkaConfig(const std::string &KafkaConfigFile) {
   if (KafkaConfigFile == "") {
     CfgParms = DefaultConfig;
     XTRACE(INIT, ALW, "KAFKA CONFIG - DEFAULT");

--- a/src/common/kafka/KafkaConfig.h
+++ b/src/common/kafka/KafkaConfig.h
@@ -17,7 +17,7 @@ class KafkaConfig {
 public:
   ///\brief Load Kafka configuration from file
   ///\param KafkaConfigFile
-  KafkaConfig(std::string KafkaConfigFile);
+  KafkaConfig(const std::string &KafkaConfigFile);
 
 public:
   // Parameters obtained from JSON config file

--- a/src/common/kafka/Producer.cpp
+++ b/src/common/kafka/Producer.cpp
@@ -17,8 +17,8 @@
 // #undef TRC_LEVEL
 // #define TRC_LEVEL TRC_L_DEB
 
-RdKafka::Conf::ConfResult Producer::setConfig(std::string Key,
-                                              std::string Value) {
+RdKafka::Conf::ConfResult Producer::setConfig(const std::string &Key,
+                                              const std::string &Value) {
   // Don't log passwords
   std::string LogValue{Value};
   if (Key == "sasl.password") {
@@ -62,7 +62,7 @@ void Producer::event_cb(RdKafka::Event &event) {
 }
 
 ///
-Producer::Producer(std::string Broker, std::string Topic,
+Producer::Producer(const std::string &Broker, const std::string &Topic,
                    std::vector<std::pair<std::string, std::string>> &Configs)
     : ProducerBase(), TopicName(Topic) {
 

--- a/src/common/kafka/Producer.h
+++ b/src/common/kafka/Producer.h
@@ -51,7 +51,7 @@ public:
   /// \param Topic The name of the Kafka topic according to the agreement, for
   /// example, "trex_detector".
   /// \param Configs A vector of configuration <type,value> pairs.
-  Producer(std::string Broker, std::string Topic,
+  Producer(const std::string &Broker, const std::string &Topic,
            std::vector<std::pair<std::string, std::string>> &Configs);
 
   /// \brief Cleans up by deleting allocated structures.
@@ -72,7 +72,7 @@ public:
   /// \param Key The configuration key.
   /// \param Value The configuration value.
   /// \return RdKafka::Conf::ConfResult The result of setting the configuration.
-  RdKafka::Conf::ConfResult setConfig(std::string Key, std::string Value);
+  RdKafka::Conf::ConfResult setConfig(const std::string &Key, const std::string &Value);
 
   /// \brief Callback function for Kafka to handle events like errors,
   /// statistics.

--- a/src/common/kafka/serializer/DA00HistogramSerializer.h
+++ b/src/common/kafka/serializer/DA00HistogramSerializer.h
@@ -116,7 +116,7 @@ public:
   /// \param Strategy is the enum like binning strategy we can select
 
   HistogramSerializer(
-      std::string Source, time_t Period, time_t BinCount, std::string DataUnit,
+      std::string Source, time_t Period, time_t BinCount, const std::string &DataUnit,
       ProducerCallback Callback = {}, R BinOffset = 0,
       essmath::VectorAggregationFunc<T> AggFunc = essmath::SUM_AGG_FUNC<T>,
       enum BinningStrategy Strategy = BinningStrategy::Drop)
@@ -151,7 +151,7 @@ public:
   /// \brief Constructor for the HistogramBuilder class.
   /// \details This constructor is used when binnig strategy is provided
   HistogramSerializer(
-      std::string Source, time_t Period, time_t BinCount, std::string Unit,
+      std::string Source, time_t Period, time_t BinCount, const std::string &Unit,
       enum BinningStrategy Strategy = BinningStrategy::Drop,
       ProducerCallback Callback = {}, R BinOffset = 0,
       essmath::VectorAggregationFunc<T> AggFunc = essmath::SUM_AGG_FUNC<T>)

--- a/src/common/kafka/serializer/FlatbufferTypes.h
+++ b/src/common/kafka/serializer/FlatbufferTypes.h
@@ -100,8 +100,8 @@ class Variable {
 public:
   /// \brief Create a new variable with a name.
   /// \param Name The name of the variable
-  explicit Variable(std::string Name) : Name(std::move(Name)) {}
-  Variable(std::string Name, std::vector<std::string> Axes,
+  explicit Variable(const std::string &Name) : Name(std::move(Name)) {}
+  Variable(const std::string &Name, std::vector<std::string> Axes,
            std::vector<int64_t> Shape)
       : Name(std::move(Name)), Axes(std::move(Axes)), Shape(std::move(Shape)) {
     if (Axes.size() != Shape.size())
@@ -346,7 +346,7 @@ public:
   /// \param SourceName The name of the data source
   /// \param ReferenceTime The reference time for this data array
   /// \param Data The vector of variables to include in the data array
-  DataArray(std::string SourceName, TimeDurationNano ReferenceTime,
+  DataArray(const std::string &SourceName, TimeDurationNano ReferenceTime,
             std::vector<Variable> Data)
       : SourceName(std::move(SourceName)),
         ReferenceTime(std::move(ReferenceTime)), Data(std::move(Data)) {}

--- a/src/common/monitor/HistogramSerializer.cpp
+++ b/src/common/monitor/HistogramSerializer.cpp
@@ -9,7 +9,7 @@ static_assert(FLATBUFFERS_LITTLEENDIAN,
               "Flatbuffers only tested on little endian systems");
 
 HistogramSerializer::HistogramSerializer(size_t buffer_half_size,
-                                         std::string source_name)
+                                         const std::string &source_name)
     : builder(2 * buffer_half_size + 256), SourceName(source_name) {}
 
 void HistogramSerializer::set_callback(ProducerCallback cb) {

--- a/src/common/monitor/HistogramSerializer.h
+++ b/src/common/monitor/HistogramSerializer.h
@@ -17,7 +17,7 @@
 class HistogramSerializer {
 public:
   /// \todo document
-  HistogramSerializer(size_t buffer_half_size, std::string source_name);
+  HistogramSerializer(size_t buffer_half_size, const std::string &source_name);
 
   void set_callback(ProducerCallback cb);
 

--- a/src/common/monitor/HitSerializer.cpp
+++ b/src/common/monitor/HitSerializer.cpp
@@ -11,7 +11,7 @@
 static_assert(FLATBUFFERS_LITTLEENDIAN,
               "Flatbuffers only tested on little endian systems");
 
-HitSerializer::HitSerializer(size_t maxarraylength, std::string source_name)
+HitSerializer::HitSerializer(size_t maxarraylength, const std::string &source_name)
     : maxlen(maxarraylength), SourceName(source_name) {
   builder.Clear();
 }

--- a/src/common/monitor/HitSerializer.h
+++ b/src/common/monitor/HitSerializer.h
@@ -19,7 +19,7 @@ public:
   /// \brief Create the HitSerializer
   /// \param maxentries the number of readout tuples to buffer before sending to
   /// Kafka
-  HitSerializer(size_t maxentries, std::string source_name);
+  HitSerializer(size_t maxentries, const std::string &source_name);
 
   void set_callback(ProducerCallback cb);
 

--- a/src/common/readout/vmm3/Hybrid.h
+++ b/src/common/readout/vmm3/Hybrid.h
@@ -22,7 +22,7 @@ public:
   static constexpr int NumVMMs{2};          // #VMMs per hybrid
   static constexpr unsigned int IdSize{32}; // chars
 
-  static bool isAvailable(std::string NewId, std::vector<Hybrid> &Hybrids) {
+  static bool isAvailable(const std::string &NewId, std::vector<Hybrid> &Hybrids) {
     for (unsigned i = 0; i < Hybrids.size(); i++) {
       if (Hybrids[i].HybridId == NewId) {
         XTRACE(INIT, ALW, "Id '%s' is already used in Hybrid %d", NewId.c_str(),

--- a/src/common/readout/vmm3/VMM3Config.cpp
+++ b/src/common/readout/vmm3/VMM3Config.cpp
@@ -115,7 +115,7 @@ void VMM3Config::applyVMM3Config() {
   }
 }
 
-void VMM3Config::loadAndApplyCalibration(std::string CalibFile) {
+void VMM3Config::loadAndApplyCalibration(const std::string &CalibFile) {
   nlohmann::json calib_root;
   try {
     calib_root = from_json_file(CalibFile);
@@ -150,11 +150,11 @@ void VMM3Config::loadAndApplyCalibration(std::string CalibFile) {
 
 /// \brief validate the hybrid id string
 /// \todo too simplistic?
-bool VMM3Config::validHybridId(std::string HybridID) {
+bool VMM3Config::validHybridId(const std::string &HybridID) {
   return (HybridID.length() == 32);
 }
 
-void VMM3Config::applyCalibration(std::string HybridID,
+void VMM3Config::applyCalibration(const std::string &HybridID,
                                   nlohmann::json Calibration) {
 
   json_check_keys("Calibration error", Calibration, {"VMMHybridCalibration"});

--- a/src/common/readout/vmm3/VMM3Config.h
+++ b/src/common/readout/vmm3/VMM3Config.h
@@ -29,7 +29,7 @@ public:
   VMM3Config(){};
 
   // Load and apply the json config
-  VMM3Config(std::string Instrument, std::string ConfigFile)
+  VMM3Config(const std::string &Instrument, const std::string &ConfigFile)
       : ExpectedName(Instrument), FileName(ConfigFile) {}
 
   // load file into json object and apply
@@ -37,7 +37,7 @@ public:
 
   /// \brief Loads calibration file and applies to each hybrid based on string
   /// ID matching CalibFile parameter = string path to calibration json file
-  void loadAndApplyCalibration(std::string CalibFile);
+  void loadAndApplyCalibration(const std::string &CalibFile);
 
   /// \brief Applies calibration json object to specified VMM on Hybrid
   void applyVMM3Calibration(ESSReadout::Hybrid &Hybrid, unsigned vmmid,
@@ -49,7 +49,7 @@ public:
   /// \brief Apply detector specific aspects of loaded configuration json file
   virtual void applyConfig() = 0;
 
-  bool validHybridId(std::string HybridID);
+  bool validHybridId(const std::string &HybridID);
 
   /// \brief Get Hybrid from the Ring, FEN, and VMM numbers
   // Currently Hybrids are stored as a 3D array, but may be updated in future
@@ -61,7 +61,7 @@ public:
   /// \brief Get Hybrid from the string Hybrid ID
   /// \todo candidate to refactor as it is nearly the same as getHybrid()
   /// check if HybridId is already configured.
-  bool lookupHybrid(std::string HybridID) {
+  bool lookupHybrid(const std::string &HybridID) {
     for (int RingID = 0; RingID <= MaxRing; RingID++) {
       for (int FENID = 0; FENID <= MaxFEN; FENID++) {
         for (int HybridNum = 0; HybridNum <= MaxHybrid; HybridNum++) {
@@ -76,7 +76,7 @@ public:
 
   /// \brief Get Hybrid from the string Hybrid ID
   // Slow string comparison method, only to be used on EFU config initialisation
-  ESSReadout::Hybrid &getHybrid(std::string HybridID) {
+  ESSReadout::Hybrid &getHybrid(const std::string &HybridID) {
     for (int RingID = 0; RingID <= MaxRing; RingID++) {
       for (int FENID = 0; FENID <= MaxFEN; FENID++) {
         for (int HybridNum = 0; HybridNum <= MaxHybrid; HybridNum++) {
@@ -92,7 +92,7 @@ public:
   }
 
   /// \brief Applies calibration to each VMM on Hybrid matching given Hybrid ID
-  void applyCalibration(std::string HybridID, nlohmann::json Calibration);
+  void applyCalibration(const std::string &HybridID, nlohmann::json Calibration);
 
 public:
   struct {

--- a/src/common/reduction/analysis/EventAnalyzer.cpp
+++ b/src/common/reduction/analysis/EventAnalyzer.cpp
@@ -14,7 +14,7 @@
 #undef TRC_MASK
 #define TRC_MASK 0
 
-EventAnalyzer::EventAnalyzer(std::string time_algorithm)
+EventAnalyzer::EventAnalyzer(const std::string &time_algorithm)
     : time_algorithm_(time_algorithm) {
   if (time_algorithm_ == "center-of-mass") {
     time_algo = TA_center_of_mass;

--- a/src/common/reduction/analysis/EventAnalyzer.h
+++ b/src/common/reduction/analysis/EventAnalyzer.h
@@ -21,7 +21,7 @@ public:
   /// uncertainty
   /// \param max_timedif maximum span of timebins to consider for upper
   /// uncertainty
-  EventAnalyzer(std::string time_algorithm);
+  EventAnalyzer(const std::string &time_algorithm);
 
   /// \brief analyzes particle track in one plane
   ReducedHit analyze(Cluster &) const;

--- a/src/common/reduction/matching/CenterMatcher.cpp
+++ b/src/common/reduction/matching/CenterMatcher.cpp
@@ -16,7 +16,7 @@ void CenterMatcher::set_max_delta_time(uint64_t max_delta_time) {
   max_delta_time_ = max_delta_time;
 }
 
-void CenterMatcher::set_time_algorithm(std::string time_algorithm) {
+void CenterMatcher::set_time_algorithm(const std::string &time_algorithm) {
   time_algorithm_ = time_algorithm;
 }
 

--- a/src/common/reduction/matching/CenterMatcher.h
+++ b/src/common/reduction/matching/CenterMatcher.h
@@ -26,7 +26,7 @@ public:
 
   /// \brief sets the time algorithm
   /// \param time_algorithm (center-of-mass, charge2, utpc, utpc-weighted)
-  void set_time_algorithm(std::string time_algorithm);
+  void set_time_algorithm(const std::string &time_algorithm);
 
   /// \brief CenterMatcher constructor
   /// \sa AbstractMatcher

--- a/src/common/reduction/multigrid/ModuleGeometry.cpp
+++ b/src/common/reduction/multigrid/ModuleGeometry.cpp
@@ -60,7 +60,7 @@ uint32_t ModuleGeometry::z_from_wire(uint16_t w) const {
   return z_offset + (flipped_z() ? flip(ret, z_range_) : ret);
 }
 
-std::string ModuleGeometry::debug(std::string prefix) const {
+std::string ModuleGeometry::debug(const std::string &prefix) const {
   std::string ret;
 
   ret += prefix +

--- a/src/common/reduction/multigrid/ModuleGeometry.h
+++ b/src/common/reduction/multigrid/ModuleGeometry.h
@@ -44,7 +44,7 @@ public:
   uint32_t y_from_grid(uint16_t g) const;
   uint32_t z_from_wire(uint16_t w) const;
 
-  std::string debug(std::string prefix = {}) const;
+  std::string debug(const std::string &prefix = {}) const;
 
 private:
   uint16_t grids_{40};

--- a/src/common/system/Socket.cpp
+++ b/src/common/system/Socket.cpp
@@ -24,7 +24,7 @@
 #define SEND_FLAGS 0
 #endif
 
-bool Socket::isValidIp(std::string ipAddress) {
+bool Socket::isValidIp(const std::string &ipAddress) {
   struct sockaddr_in SockAddr;
   return inet_pton(AF_INET, ipAddress.c_str(), &(SockAddr.sin_addr)) != 0;
 }

--- a/src/common/system/Socket.h
+++ b/src/common/system/Socket.h
@@ -35,7 +35,7 @@ public:
   /// \brief Is this a dotted quad ip address?
   /// Valid addresses must be of the form 'a.b.d.c' where
   /// a-d can range from 0 to 255
-  static bool isValidIp(std::string ipAddress);
+  static bool isValidIp(const std::string &ipAddress);
 
   /// \brief Return dotted quad by resolving hostname
   /// Essentially a wrapper for gethostbyname() returning
@@ -56,7 +56,7 @@ public:
   void setMulticastTTL();
 
   /// Allow reuse of ip and port, send igmp membership info
-  // void setMulticastReceive(std::string MultiCastAddress);
+  // void setMulticastReceive(const std::string &MultiCastAddress);
   void setMulticastReceive();
 
   /// Attempt to specify the socket receive and transmit buffer sizes (for
@@ -99,7 +99,7 @@ public:
   bool isValidSocket();
 
   /// \brief Check if address is IP multicast (Class 'D')
-  static bool isMulticast(std::string IpAddress) {
+  static bool isMulticast(const std::string &IpAddress) {
     return IN_MULTICAST(ntohl(inet_addr(IpAddress.c_str())));
   };
 

--- a/src/common/testutils/SaveBuffer.cpp
+++ b/src/common/testutils/SaveBuffer.cpp
@@ -12,7 +12,7 @@
 #include <unistd.h>
 // GCOVR_EXCL_START
 
-void saveBuffer(std::string filename, void *buffer, uint64_t datasize) {
+void saveBuffer(const std::string &filename, void *buffer, uint64_t datasize) {
   int fd;
   const int flags = O_TRUNC | O_CREAT | O_RDWR;
   const int mode = S_IRUSR | S_IWUSR;

--- a/src/common/testutils/SaveBuffer.h
+++ b/src/common/testutils/SaveBuffer.h
@@ -13,7 +13,7 @@
 #include <string>
 
 /// \brief save buffer to file
-void saveBuffer(std::string filename, void *buffer, uint64_t datasize);
+void saveBuffer(const std::string &filename, void *buffer, uint64_t datasize);
 
 /// \brief helper function to remove temporary files after test
 void deleteFile(const std::string &filename);

--- a/src/common/testutils/TestBase.h
+++ b/src/common/testutils/TestBase.h
@@ -64,7 +64,7 @@ class TestBase : public ::testing::Test {
 protected:
   class Message : public std::stringstream {
   public:
-    static void saveToFile(std::string filename, void *buffer,
+    static void saveToFile(const std::string &filename, void *buffer,
                            uint64_t datasize);
   };
 

--- a/src/efu/Graylog.cpp
+++ b/src/efu/Graylog.cpp
@@ -65,9 +65,9 @@ void Graylog::EmptyGraylogMessageQueue() {
   Log::RemoveAllHandlers();
 }
 
-void Graylog::AddLoghandlerForNetwork(std::string DetectorName,
-                                      std::string FileName, int LogLevel,
-                                      std::string Address, int Port) {
+void Graylog::AddLoghandlerForNetwork(const std::string &DetectorName,
+                                      const std::string &FileName, int LogLevel,
+                                      const std::string &Address, int Port) {
   // Set-up logging before we start doing important stuff
   // change process to "efu" and set process_name to Instrument
   std::string ProcessKey{"process"};

--- a/src/efu/Graylog.h
+++ b/src/efu/Graylog.h
@@ -22,6 +22,6 @@ public:
 
   void EmptyGraylogMessageQueue();
 
-  void AddLoghandlerForNetwork(std::string DetectorName, std::string FileName,
-                               int LogLevel, std::string Address, int Port);
+  void AddLoghandlerForNetwork(const std::string &DetectorName, const std::string &FileName,
+                               int LogLevel, const std::string &Address, int Port);
 };

--- a/src/efu/HwCheck.cpp
+++ b/src/efu/HwCheck.cpp
@@ -37,7 +37,7 @@ bool HwCheck::ignoreInterface(char * IfName) {
 /// returned by getifaddrs() of type AF_INET, which are both UP and RUNNING.
 /// There is also support for ignoring certain interface name patterns to remove
 /// MTU check for irrelevant interfaces such as ppp0 and docker0
-bool HwCheck::checkMTU(std::vector<std::string> InterfaceList, bool PrintOnSuccess) {
+bool HwCheck::checkMTU(const std::vector<std::string> &InterfaceList, bool PrintOnSuccess) {
   CheckedInterfaces = InterfaceList;
   int MatchCount{0};
   struct ifaddrs *ifaddr, *ifa;

--- a/src/efu/HwCheck.h
+++ b/src/efu/HwCheck.h
@@ -27,14 +27,14 @@ public:
   bool ignoreInterface(char * IfName);
 
   /// \brief Select interfaces to check
-  bool checkMTU(std::vector<std::string> ignore, bool PrintOnSuccess = false);
+  bool checkMTU(const std::vector<std::string> &ignore, bool PrintOnSuccess = false);
 
   /// setter for MTU size check, mostly used for reverting
   /// to a lower MTU size, when running on ad hoc servers
   void setMinimumMTU(int mtu) { MinimumMtu = mtu; }
 
   /// \brief
-  // bool checkDiskSpace(std::vector<std::string> checkdirs);
+  // bool checkDiskSpace(const std::vector<std::string> &checkdirs);
 
   /// \brief
   // std::vector<std::string> DirectoriesToCheck = {".", "/"};

--- a/src/efu/MainProg.cpp
+++ b/src/efu/MainProg.cpp
@@ -15,7 +15,7 @@
 #include <efu/Parser.h>
 #include <efu/Server.h>
 
-MainProg::MainProg(std::string instrument, int argc, char *argv[]) {
+MainProg::MainProg(const std::string &instrument, int argc, char *argv[]) {
 
   if (Args.parseArgs(argc, argv) != EFUArgs::Status::CONTINUE) {
     exit(0);

--- a/src/efu/MainProg.h
+++ b/src/efu/MainProg.h
@@ -18,7 +18,7 @@ public:
   /// \brief initialise by passing the instrument name and the arguments
   /// cannot return but uses exit() instead.
   /// constructor - roughly this is first half of the old main() function
-  MainProg(std::string instrument, int argc, char *argv[]);
+  MainProg(const std::string &instrument, int argc, char *argv[]);
 
   /// \brief setup exithandlers, launch detector - roughly equivalent to the
   /// second half of the old main()

--- a/src/efu/Parser.cpp
+++ b/src/efu/Parser.cpp
@@ -39,7 +39,7 @@ static int stat_get_count(const std::vector<std::string> &cmdargs, char *output,
 }
 
 //=============================================================================
-static int stat_get(std::vector<std::string> cmdargs, char *output,
+static int stat_get(const std::vector<std::string> &cmdargs, char *output,
                     unsigned int *obytes, std::shared_ptr<Detector> detector,
                     Statistics stats) {
   auto nargs = cmdargs.size();
@@ -74,7 +74,7 @@ static int stat_get(std::vector<std::string> cmdargs, char *output,
 /// \param obytes pointer (UNUSED) to the number of chars in the buffer
 /// \param detector pointer to detector instance
 /// \return status negative for error
-static int calib_mode_set(std::vector<std::string> cmdargs,
+static int calib_mode_set(const std::vector<std::string> &cmdargs,
                           __attribute__((unused)) char *output,
                           __attribute__((unused)) unsigned int *obytes,
                           std::shared_ptr<Detector> detector) {
@@ -100,7 +100,7 @@ static int calib_mode_set(std::vector<std::string> cmdargs,
 /// \param obytes pointer to the number of chars in the buffer
 /// \param detector pointer to detector instance
 /// \return status negative for error
-static int calib_mode_get(std::vector<std::string> cmdargs, char *output,
+static int calib_mode_get(const std::vector<std::string> &cmdargs, char *output,
                           unsigned int *obytes,
                           std::shared_ptr<Detector> detector) {
   LOG(CMD, Sev::Debug, "CALIB_MODE_GET");
@@ -137,7 +137,7 @@ static int version_get(const std::vector<std::string> &cmdargs, char *output,
 }
 
 //=============================================================================
-static int stat_get_name(std::vector<std::string> cmdargs, char *output,
+static int stat_get_name(const std::vector<std::string> &cmdargs, char *output,
                          unsigned int *obytes,
                          std::shared_ptr<Detector> detector, Statistics stats) {
   auto nargs = cmdargs.size();
@@ -178,7 +178,7 @@ static int cmd_get_count(const std::vector<std::string> &cmdargs, char *output,
 }
 
 //=============================================================================
-static int cmd_get(std::vector<std::string> cmdargs, char *output,
+static int cmd_get(const std::vector<std::string> &cmdargs, char *output,
                    unsigned int *obytes, Parser *parser) {
   auto nargs = cmdargs.size();
   LOG(CMD, Sev::Debug, "CMD_GET");

--- a/src/generators/udpgen_hits/ReaderHits.cpp
+++ b/src/generators/udpgen_hits/ReaderHits.cpp
@@ -12,7 +12,7 @@
 
 namespace Gem {
 
-ReaderHits::ReaderHits(std::string filename) {
+ReaderHits::ReaderHits(const std::string &filename) {
   file = HitFile::open(filename);
   total_ = file->count();
   ReadoutSize = sizeof(Hit);

--- a/src/generators/udpgen_hits/ReaderHits.h
+++ b/src/generators/udpgen_hits/ReaderHits.h
@@ -17,7 +17,7 @@ namespace Gem {
 class ReaderHits {
 public:
   /// \todo document
-  ReaderHits(std::string filename);
+  ReaderHits(const std::string &filename);
 
   /// \todo document
   size_t read(char *buf);

--- a/src/generators/udpgenpcap/ReaderPcap.cpp
+++ b/src/generators/udpgenpcap/ReaderPcap.cpp
@@ -29,7 +29,7 @@ const int UDP_HEADER_SIZE = 8;
 int UDP_HEADER_OFFSET;
 int UDP_DATA_OFFSET;
 
-ReaderPcap::ReaderPcap(std::string FileName) : FileName(FileName) {
+ReaderPcap::ReaderPcap(const std::string &FileName) : FileName(FileName) {
   memset(&Stats, 0, sizeof(stats_t));
 }
 

--- a/src/generators/udpgenpcap/ReaderPcap.h
+++ b/src/generators/udpgenpcap/ReaderPcap.h
@@ -18,7 +18,7 @@ class ReaderPcap {
 public:
   /// \brief construct a reader for a specific file
   /// \param filename name of pcap file
-  ReaderPcap(std::string FileName);
+  ReaderPcap(const std::string &FileName);
 
   /// closes pcap handle
   ~ReaderPcap();

--- a/src/modules/caen/generators/ReaderReadouts.cpp
+++ b/src/modules/caen/generators/ReaderReadouts.cpp
@@ -14,7 +14,7 @@
 
 namespace Caen {
 
-ReaderReadouts::ReaderReadouts(std::string filename) {
+ReaderReadouts::ReaderReadouts(const std::string &filename) {
   file = ReadoutFile::open(filename);
   total_ = file->count();
   ReadoutSize = sizeof(Readout);

--- a/src/modules/caen/generators/ReaderReadouts.h
+++ b/src/modules/caen/generators/ReaderReadouts.h
@@ -23,7 +23,7 @@ class ReaderReadouts {
 public:
   /// \brief open H5 file for later reading, save ChunkSize
   /// also sets a few internal counters.
-  ReaderReadouts(std::string filename);
+  ReaderReadouts(const std::string &filename);
 
   /// \brief read from H5 file and format an ESS Readout data
   /// The read function keeps track of changing pulse times and

--- a/src/modules/caen/generators/ReadoutGenerator.h
+++ b/src/modules/caen/generators/ReadoutGenerator.h
@@ -37,7 +37,7 @@ public:
   ReadoutGenerator();
 
 
-  void setTypeByName(std::string Name) {
+  void setTypeByName(const std::string &Name) {
       Settings.TypeOverride = NameToType[Name];
       printf("Detector %s has type %u\n", Name.c_str(),
              Settings.TypeOverride);

--- a/src/modules/caen/geometry/CDCalibration.cpp
+++ b/src/modules/caen/geometry/CDCalibration.cpp
@@ -23,7 +23,7 @@
 namespace Caen {
 
 /// loads calibration from file
-CDCalibration::CDCalibration(std::string Name, std::string CalibrationFile)
+CDCalibration::CDCalibration(const std::string &Name, const std::string &CalibrationFile)
     : Name(Name) {
 
   LOG(INIT, Sev::Info, "Loading calibration file {}", CalibrationFile);
@@ -219,7 +219,7 @@ bool CDCalibration::inUnitInterval(std::pair<double, double> &Pair) {
           (Pair.second >= 0.0) and (Pair.second <= 1.0));
 }
 
-void CDCalibration::throwException(std::string Message) {
+void CDCalibration::throwException(const std::string &Message) {
   XTRACE(INIT, ERR, "%s", Message.c_str());
   LOG(INIT, Sev::Error, Message);
   throw std::runtime_error(Message);

--- a/src/modules/caen/geometry/CDCalibration.h
+++ b/src/modules/caen/geometry/CDCalibration.h
@@ -25,11 +25,11 @@ public:
 
   /// \brief this constructor just saves the detector name, used in
   /// unit tests.
-  CDCalibration(std::string Name) : Name(Name){};
+  CDCalibration(const std::string &Name) : Name(Name){};
 
   /// \brief load json from file into the jsion root object, used
   /// in detector plugin.
-  CDCalibration(std::string Name, std::string CalibrationFile);
+  CDCalibration(const std::string &Name, const std::string &CalibrationFile);
 
   /// \brief parse the calibration and validate internal consistency
   /// \retval True if file is valid, else False.
@@ -75,7 +75,7 @@ public:
 
 private:
   ///\brief log and trace then throw runtime exception
-  void throwException(std::string Message);
+  void throwException(const std::string &Message);
 
   ///\brief Do an initial sanity check of the provided json file
   /// called from parseCaibration()

--- a/src/modules/caen/geometry/Config.cpp
+++ b/src/modules/caen/geometry/Config.cpp
@@ -18,7 +18,7 @@ namespace Caen {
 ///
 Config::Config() {}
 
-Config::Config(std::string ConfigFile) : ConfigFileName(ConfigFile) {
+Config::Config(const std::string &ConfigFile) : ConfigFileName(ConfigFile) {
   XTRACE(INIT, DEB, "Loading json file");
   root = from_json_file(ConfigFile);
   XTRACE(INIT, DEB, "Loaded json file");

--- a/src/modules/caen/geometry/Config.h
+++ b/src/modules/caen/geometry/Config.h
@@ -27,7 +27,7 @@ public:
   Config();
 
   ///\brief constructor used in EFU to load json from file
-  Config(std::string ConfigFile);
+  Config(const std::string &ConfigFile);
 
   ///\brief parse the loaded json object
   void parseConfig();

--- a/src/modules/cbm/geometry/Config.cpp
+++ b/src/modules/cbm/geometry/Config.cpp
@@ -13,7 +13,7 @@ namespace cbm {
 // #undef TRC_LEVEL
 // #define TRC_LEVEL TRC_L_DEB
 
-void Config::errorExit(std::string ErrMsg) {
+void Config::errorExit(const std::string &ErrMsg) {
   LOG(INIT, Sev::Error, ErrMsg);
   throw std::runtime_error(ErrMsg);
 }

--- a/src/modules/cbm/geometry/Config.h
+++ b/src/modules/cbm/geometry/Config.h
@@ -53,10 +53,10 @@ struct Topology {
 
 class Config {
 
-  void errorExit(std::string ErrMsg);
+  void errorExit(const std::string &ErrMsg);
 
 public:
-  Config(std::string ConfigFile) : FileName(ConfigFile){};
+  Config(const std::string &ConfigFile) : FileName(ConfigFile){};
 
   Config(){};
 

--- a/src/modules/dream/geometry/Config.cpp
+++ b/src/modules/dream/geometry/Config.cpp
@@ -14,7 +14,7 @@
 
 namespace Dream {
 
-void Config::errorExit(std::string ErrMsg) {
+void Config::errorExit(const std::string &ErrMsg) {
   LOG(INIT, Sev::Error, ErrMsg);
   throw std::runtime_error(ErrMsg);
 }

--- a/src/modules/dream/geometry/Config.h
+++ b/src/modules/dream/geometry/Config.h
@@ -59,7 +59,7 @@ public:
   };
 
   //
-  Config(std::string ConfigFile) : FileName(ConfigFile) {
+  Config(const std::string &ConfigFile) : FileName(ConfigFile) {
     memset(RMConfig, 0, sizeof(RMConfig));
   };
 
@@ -73,7 +73,7 @@ public:
   void apply();
 
   /// \brief log errormessage and throw runtime exception
-  void errorExit(std::string errmsg);
+  void errorExit(const std::string &errmsg);
 
   uint32_t MaxPulseTimeDiffNS{5 * 71'428'571}; // 5 * 1/14 * 10^9
 

--- a/src/modules/freia/FreiaInstrument.h
+++ b/src/modules/freia/FreiaInstrument.h
@@ -40,7 +40,7 @@ public:
   /// \brief after loading the config file, Config.HybridIdStr contains
   /// a vector of HybridIds. These are then loaded into the Hybrids so that
   /// we can later do consistency checks when applying the calibration data
-  void setHybridIds(std::vector<std::string> Ids);
+  void setHybridIds(const std::vector<std::string> &Ids);
 
   /// \brief process parsed vmm data into clusters
   void processReadouts(void);

--- a/src/modules/freia/geometry/Config.h
+++ b/src/modules/freia/geometry/Config.h
@@ -29,7 +29,7 @@ public:
   Config() { FileParameters.InstrumentGeometry = "Freia"; };
 
   // Load and apply the json config
-  Config(std::string Instrument, std::string ConfigFile)
+  Config(const std::string &Instrument, const std::string &ConfigFile)
       : VMM3Config(Instrument, ConfigFile) {}
 
   // Apply the loaded json file

--- a/src/modules/freia/geometry/Geometry.h
+++ b/src/modules/freia/geometry/Geometry.h
@@ -24,7 +24,7 @@ class Geometry {
 public:
   Geometry() { GeometryInst = &FreiaGeom; }
 
-  bool setGeometry(std::string NewGeometry) {
+  bool setGeometry(const std::string &NewGeometry) {
     if (NewGeometry == "AMOR") {
       GeometryInst = &AMORGeom;
       return true;

--- a/src/modules/loki/geometry/LokiConfig.cpp
+++ b/src/modules/loki/geometry/LokiConfig.cpp
@@ -18,7 +18,7 @@ namespace Caen {
 ///
 LokiConfig::LokiConfig() {}
 
-LokiConfig::LokiConfig(std::string ConfigFile) : ConfigFileName(ConfigFile) {
+LokiConfig::LokiConfig(const std::string &ConfigFile) : ConfigFileName(ConfigFile) {
   XTRACE(INIT, DEB, "Loading json file");
   root = from_json_file(ConfigFile);
 }

--- a/src/modules/loki/geometry/LokiConfig.h
+++ b/src/modules/loki/geometry/LokiConfig.h
@@ -24,7 +24,7 @@ public:
   LokiConfig();
 
   ///\brief constructor used in EFU to load json from file
-  LokiConfig(std::string ConfigFile);
+  LokiConfig(const std::string &ConfigFile);
 
   ///\brief parse the loaded json object
   void parseConfig();

--- a/src/modules/miracles/generators/DatReader.cpp
+++ b/src/modules/miracles/generators/DatReader.cpp
@@ -16,7 +16,7 @@
 
 // GCOVR_EXCL_START
 
-MiraclesDatReader::MiraclesDatReader(std::string file, bool Verbose)
+MiraclesDatReader::MiraclesDatReader(const std::string &file, bool Verbose)
     : filename(file), Verbose(Verbose) {
   infile = new std::ifstream(filename);
 }

--- a/src/modules/miracles/generators/DatReader.h
+++ b/src/modules/miracles/generators/DatReader.h
@@ -30,7 +30,7 @@ public:
   static_assert(sizeof(struct dat_data_t) == 24, "wrong packing");
 
   //
-  MiraclesDatReader(std::string file, bool Verbose);
+  MiraclesDatReader(const std::string &file, bool Verbose);
 
   // Read a CDTReadout struct, return bytes read, 0 if line is
   // ignored, or -1 upon error/end

--- a/src/modules/nmx/geometry/Config.h
+++ b/src/modules/nmx/geometry/Config.h
@@ -30,7 +30,7 @@ public:
   Config() { FileParameters.InstrumentGeometry = "NMX"; };
 
   // Load and apply the json config
-  Config(std::string Instrument, std::string ConfigFile)
+  Config(const std::string &Instrument, const std::string &ConfigFile)
       : VMM3Config(Instrument, ConfigFile) {}
 
   // Apply the loaded json file

--- a/src/modules/tbl3he/geometry/Tbl3HeConfig.cpp
+++ b/src/modules/tbl3he/geometry/Tbl3HeConfig.cpp
@@ -22,13 +22,13 @@ namespace Caen {
 ///
 Tbl3HeConfig::Tbl3HeConfig() {}
 
-Tbl3HeConfig::Tbl3HeConfig(std::string ConfigFile)
+Tbl3HeConfig::Tbl3HeConfig(const std::string &ConfigFile)
     : ConfigFile(ConfigFile), ConfigFileName(ConfigFile) {
   XTRACE(INIT, DEB, "Loading json file");
   root = from_json_file(ConfigFile);
 }
 
-void Tbl3HeConfig::errorExit(std::string ErrMsg) {
+void Tbl3HeConfig::errorExit(const std::string &ErrMsg) {
   LOG(INIT, Sev::Error, ErrMsg);
   XTRACE(INIT, ERR, "%s\n", ErrMsg.c_str());
   sleep(1);

--- a/src/modules/tbl3he/geometry/Tbl3HeConfig.h
+++ b/src/modules/tbl3he/geometry/Tbl3HeConfig.h
@@ -25,10 +25,10 @@ public:
   Tbl3HeConfig();
 
   ///\brief constructor used in EFU to load json from file
-  Tbl3HeConfig(std::string ConfigFile);
+  Tbl3HeConfig(const std::string &ConfigFile);
 
   // wrapper function for runtime exception
-  void errorExit(std::string ErrMsg);
+  void errorExit(const std::string &ErrMsg);
 
 
   ///\brief parse the loaded json object

--- a/src/modules/timepix3/geometry/Config.cpp
+++ b/src/modules/timepix3/geometry/Config.cpp
@@ -19,7 +19,7 @@ namespace Timepix3 {
 ///
 Config::Config() {}
 
-Config::Config(std::string ConfigFile) {
+Config::Config(const std::string &ConfigFile) {
   XTRACE(INIT, DEB, "Loading json file");
   nlohmann::json root = from_json_file(ConfigFile);
   XTRACE(INIT, DEB, "Loaded json file");

--- a/src/modules/timepix3/geometry/Config.h
+++ b/src/modules/timepix3/geometry/Config.h
@@ -22,7 +22,7 @@ class Config {
 public:
   Config();
 
-  Config(std::string ConfigFile);
+  Config(const std::string &ConfigFile);
 
   std::string InstrumentName;
   uint16_t XResolution{0};  /// Resolution along x axis

--- a/src/modules/trex/geometry/Config.h
+++ b/src/modules/trex/geometry/Config.h
@@ -30,7 +30,7 @@ public:
   Config() { FileParameters.InstrumentGeometry = "TREX"; };
 
   // Load and apply the json config
-  Config(std::string Instrument, std::string ConfigFile)
+  Config(const std::string &Instrument, const std::string &ConfigFile)
       : VMM3Config(Instrument, ConfigFile) {}
 
   // Apply the loaded json file


### PR DESCRIPTION
### Issue reference / description
https://jira.ess.eu/browse/ECDC-4519

Several functions are passing `std::string` variables by value generating a redundant copy

```
void foo(std::string bar, ...
```
Modify these to be passed as const and by reference, i.e.

```
void foo(const std::string &bar, ...
```
## Checklist for submitter

- [x] Check for conflict with integration test
- [x] Unit tests pass

---

### Nominate for Group Code Review

- [x] Nominate for code review
