### PR TITLE
ECDC-4535: EFU source code typos - fix-up

### DIFF
--- a/documentation/minimaldetector/minimaldetector.cpp
+++ b/documentation/minimaldetector/minimaldetector.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 European Spallation Source, ERIC. See LICENSE file */
+// Copyright (C) 2018 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/DumpFile.h
+++ b/src/common/DumpFile.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/JsonFile.h
+++ b/src/common/JsonFile.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2019 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/RuntimeStat.h
+++ b/src/common/RuntimeStat.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/StatPublisher.cpp
+++ b/src/common/StatPublisher.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/StatPublisher.h
+++ b/src/common/StatPublisher.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/Statistics.cpp
+++ b/src/common/Statistics.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2023 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/Statistics.h
+++ b/src/common/Statistics.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2023 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/debug/Assert.h
+++ b/src/common/debug/Assert.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/debug/Expect.h
+++ b/src/common/debug/Expect.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/debug/Log.h
+++ b/src/common/debug/Log.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/debug/Trace.h
+++ b/src/common/debug/Trace.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2018 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/debug/TraceGroups.h
+++ b/src/common/debug/TraceGroups.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/kafka/EV44Serializer.cpp
+++ b/src/common/kafka/EV44Serializer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2022 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file
@@ -100,7 +100,7 @@ size_t EV44Serializer::produce() {
     XTRACE(OUTPUT, DEB, "autoproduce %zu EventCount_ \n", EventCount);
     serialize();
     if (ProduceFunctor) {
-      
+
       // produce kafka message timestamp with current timestamp from hardware
       // clock
       uint64_t currentHwClock =

--- a/src/common/kafka/EV44Serializer.h
+++ b/src/common/kafka/EV44Serializer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2022 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/kafka/Producer.cpp
+++ b/src/common/kafka/Producer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/kafka/Producer.h
+++ b/src/common/kafka/Producer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/kafka/serializer/AbstractSerializer.cpp
+++ b/src/common/kafka/serializer/AbstractSerializer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 European Spallation Source, see LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/kafka/serializer/AbstractSerializer.h
+++ b/src/common/kafka/serializer/AbstractSerializer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/kafka/serializer/DA00HistogramSerializer.h
+++ b/src/common/kafka/serializer/DA00HistogramSerializer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, ERIC. see LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, ERIC. see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/kafka/test/KafkaMocks.h
+++ b/src/common/kafka/test/KafkaMocks.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2018 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/kafka/test/ProducerTest.cpp
+++ b/src/common/kafka/test/ProducerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2022 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/math/BitMath.h
+++ b/src/common/math/BitMath.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/memory/Buffer.h
+++ b/src/common/memory/Buffer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, see LICENSE file
+// Copyright (C) 2016 - 2018 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/memory/FixedSizePool.h
+++ b/src/common/memory/FixedSizePool.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/memory/HashMap2D.h
+++ b/src/common/memory/HashMap2D.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/memory/PoolAllocator.h
+++ b/src/common/memory/PoolAllocator.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/memory/RingBuffer.h
+++ b/src/common/memory/RingBuffer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/monitor/Histogram.h
+++ b/src/common/monitor/Histogram.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2018 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/monitor/HistogramSerializer.h
+++ b/src/common/monitor/HistogramSerializer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2018 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/monitor/HitSerializer.h
+++ b/src/common/monitor/HitSerializer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2018 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/monitor/Monitor.cpp
+++ b/src/common/monitor/Monitor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source
+// Copyright (C) 2016 - 2018 European Spallation Source
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/readout/ess/ParserTest.cpp
+++ b/src/common/readout/ess/ParserTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2017 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/readout/ess/ParserTestData.h
+++ b/src/common/readout/ess/ParserTestData.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2017 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/readout/vmm3/test/VMM3ConfigTest.cpp
+++ b/src/common/readout/vmm3/test/VMM3ConfigTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/readout/vmm3/test/VMM3ParserTest.cpp
+++ b/src/common/readout/vmm3/test/VMM3ParserTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2017 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/readout/vmm3/test/VMM3ParserTestData.h
+++ b/src/common/readout/vmm3/test/VMM3ParserTestData.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 - 2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2021 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/reduction/Cluster.h
+++ b/src/common/reduction/Cluster.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file Cluster.h

--- a/src/common/reduction/Cluster2D.h
+++ b/src/common/reduction/Cluster2D.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file Cluster2D.h

--- a/src/common/reduction/Event.h
+++ b/src/common/reduction/Event.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2018 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file Event.h

--- a/src/common/reduction/Hit.h
+++ b/src/common/reduction/Hit.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2017 - 2018 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 ///                              WARNING

--- a/src/common/reduction/analysis/EventAnalyzer.h
+++ b/src/common/reduction/analysis/EventAnalyzer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2018 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/reduction/clustering/AbstractClusterer.cpp
+++ b/src/common/reduction/clustering/AbstractClusterer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2019 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file AbstractClusterer.cpp

--- a/src/common/reduction/clustering/AbstractClusterer.h
+++ b/src/common/reduction/clustering/AbstractClusterer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2019 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file AbstractClusterer.h

--- a/src/common/reduction/clustering/GapClusterer.cpp
+++ b/src/common/reduction/clustering/GapClusterer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2019 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file GapClusterer.cpp

--- a/src/common/reduction/clustering/GapClusterer.h
+++ b/src/common/reduction/clustering/GapClusterer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2019 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file GapClusterer.h

--- a/src/common/reduction/clustering/GapClusterer2D.cpp
+++ b/src/common/reduction/clustering/GapClusterer2D.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2019 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file GapClusterer2D.cpp

--- a/src/common/reduction/clustering/GapClusterer2D.h
+++ b/src/common/reduction/clustering/GapClusterer2D.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2019 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file GapClusterer2D.h

--- a/src/common/reduction/clustering/Hierarchical2DClusterer.cpp
+++ b/src/common/reduction/clustering/Hierarchical2DClusterer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file Hierarchical2DClusterer.cpp

--- a/src/common/reduction/matching/GapMatcher.cpp
+++ b/src/common/reduction/matching/GapMatcher.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2022 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file GapMatcher.h

--- a/src/common/reduction/matching/test/GapMatcherTest.cpp
+++ b/src/common/reduction/matching/test/GapMatcherTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2022 European Spallation Source ERIC
+// Copyright (C) 2017 - 2022 European Spallation Source ERIC
 
 #include <common/reduction/matching/GapMatcher.h>
 

--- a/src/common/system/Socket.cpp
+++ b/src/common/system/Socket.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/system/Socket.h
+++ b/src/common/system/Socket.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/system/gccintel.h
+++ b/src/common/system/gccintel.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2018 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/test/ESSTimeTest.cpp
+++ b/src/common/test/ESSTimeTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2019 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/test/FixedSizePoolTest.cpp
+++ b/src/common/test/FixedSizePoolTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2024 European Spallation Source, ERIC. See LICENSE file
 
 #include <common/memory/FixedSizePool.h>
 #include <common/testutils/TestBase.h>

--- a/src/common/test/PoolAllocatorTest.cpp
+++ b/src/common/test/PoolAllocatorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2020 European Spallation Source, ERIC. See LICENSE file
 
 #include <common/memory/PoolAllocator.h>
 #include <common/testutils/TestBase.h>

--- a/src/common/testutils/BenchmarkUtil.h
+++ b/src/common/testutils/BenchmarkUtil.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/testutils/SaveBuffer.cpp
+++ b/src/common/testutils/SaveBuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/testutils/SaveBuffer.h
+++ b/src/common/testutils/SaveBuffer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/time/CheckTimer.cpp
+++ b/src/common/time/CheckTimer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/time/ESSTime.cpp
+++ b/src/common/time/ESSTime.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2019 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/time/TSCTimer.cpp
+++ b/src/common/time/TSCTimer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/time/TSCTimer.h
+++ b/src/common/time/TSCTimer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/time/TimeString.cpp
+++ b/src/common/time/TimeString.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2017 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/time/TimeString.h
+++ b/src/common/time/TimeString.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/time/Timer.cpp
+++ b/src/common/time/Timer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/common/time/Timer.h
+++ b/src/common/time/Timer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/efu/ExitHandler.cpp
+++ b/src/efu/ExitHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/efu/ExitHandler.h
+++ b/src/efu/ExitHandler.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/efu/HwCheck.cpp
+++ b/src/efu/HwCheck.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/efu/HwCheck.h
+++ b/src/efu/HwCheck.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2018 - 2020 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/efu/Launcher.cpp
+++ b/src/efu/Launcher.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/efu/Launcher.h
+++ b/src/efu/Launcher.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/efu/Parser.h
+++ b/src/efu/Parser.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/efu/Server.cpp
+++ b/src/efu/Server.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/efu/Server.h
+++ b/src/efu/Server.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2016 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/generators/functiongenerators/DistributionGeneratorTest.cpp
+++ b/src/generators/functiongenerators/DistributionGeneratorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2019 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/generators/udpgen_hits/ReaderHits.cpp
+++ b/src/generators/udpgen_hits/ReaderHits.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, see LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/generators/udpgen_hits/ReaderHits.h
+++ b/src/generators/udpgen_hits/ReaderHits.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, see LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/generators/udpgen_hits/generator.cpp
+++ b/src/generators/udpgen_hits/generator.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2020 European Spallation Source, see LICENSE file
+// Copyright (C) 2016 - 2020 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/generators/udpgenpcap/ReaderPcap.cpp
+++ b/src/generators/udpgenpcap/ReaderPcap.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2016 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/generators/udpgenpcap/ReaderPcap.h
+++ b/src/generators/udpgenpcap/ReaderPcap.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2016 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/generators/udpgenpcap/udpgen_pcap.cpp
+++ b/src/generators/udpgenpcap/udpgen_pcap.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2016 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
       PcapPackets++;
 
       if (PcapPackets >= Settings.PcapOffset) {
-        
+
         if (Settings.SpeedThrottle) {
           usleep(Settings.SpeedThrottle);
         } else {

--- a/src/modules/caen/CaenCounters.h
+++ b/src/modules/caen/CaenCounters.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2019 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/caen/CaenInstrument.h
+++ b/src/modules/caen/CaenInstrument.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/caen/generators/ReadoutGenerator.cpp
+++ b/src/modules/caen/generators/ReadoutGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/caen/geometry/CDCalibration.h
+++ b/src/modules/caen/geometry/CDCalibration.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/caen/test/DataParserTest.cpp
+++ b/src/modules/caen/test/DataParserTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2022 European Spallation Source ERIC
+// Copyright (C) 2016 - 2022 European Spallation Source ERIC
 
 #include <caen/readout/DataParser.h>
 #include <caen/test/DataParserTestData.h>

--- a/src/modules/caen/test/DataParserTestData.h
+++ b/src/modules/caen/test/DataParserTestData.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2019 - 2022 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/cbm/CbmInstrument.h
+++ b/src/modules/cbm/CbmInstrument.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2022 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/cbm/Counters.h
+++ b/src/modules/cbm/Counters.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2022 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/cbm/geometry/Config.cpp
+++ b/src/modules/cbm/geometry/Config.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2022 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/cbm/geometry/Config.h
+++ b/src/modules/cbm/geometry/Config.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2022 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/cbm/test/CbmInstrumentTest.cpp
+++ b/src/modules/cbm/test/CbmInstrumentTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 - 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2021 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file Unit test for the CbmInstrument class.

--- a/src/modules/cbm/test/ConfigTest.cpp
+++ b/src/modules/cbm/test/ConfigTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2022 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/dream/DreamInstrument.h
+++ b/src/modules/dream/DreamInstrument.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 - 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2021 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/dream/generators/ReadoutGenerator.cpp
+++ b/src/modules/dream/generators/ReadoutGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 - 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/dream/geometry/Config.cpp
+++ b/src/modules/dream/geometry/Config.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 - 2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2021 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/freia/FreiaInstrument.h
+++ b/src/modules/freia/FreiaInstrument.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2021 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/freia/test/FreiaInstrumentTest.cpp
+++ b/src/modules/freia/test/FreiaInstrumentTest.cpp
@@ -28,7 +28,7 @@ std::string CalibStr = R"(
   "Calibrations" : [
     { "VMMHybridCalibration" : {
         "HybridId" : "E5533333222222221111111100000000",
-        "CalibrationDate" : "20210222-124533",
+        "CalibrationDate" : "20210222 - 124533",
 
         "vmm0" : {
           "Settings" : "all ain and no pain",

--- a/src/modules/loki/generators/LokiReadoutGenerator.cpp
+++ b/src/modules/loki/generators/LokiReadoutGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2022 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/loki/geometry/LokiConfig.h
+++ b/src/modules/loki/geometry/LokiConfig.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/loki/test/LokiFullGeometryTestData.h
+++ b/src/modules/loki/test/LokiFullGeometryTestData.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2021 - 2022 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/nmx/NMXInstrument.h
+++ b/src/modules/nmx/NMXInstrument.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/perfgen/PerfGenBase.h
+++ b/src/modules/perfgen/PerfGenBase.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/tbl3he/geometry/Tbl3HeGeometry.cpp
+++ b/src/modules/tbl3he/geometry/Tbl3HeGeometry.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/tbl3he/geometry/Tbl3HeGeometry.h
+++ b/src/modules/tbl3he/geometry/Tbl3HeGeometry.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/Timepix3Base.cpp
+++ b/src/modules/timepix3/Timepix3Base.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 European Spallation Source, see LICENSE file
+// Copyright (C) 2023 - 2025 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/Timepix3Instrument.h
+++ b/src/modules/timepix3/Timepix3Instrument.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/dataflow/DataObserverTemplate.h
+++ b/src/modules/timepix3/dataflow/DataObserverTemplate.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/geometry/Config.cpp
+++ b/src/modules/timepix3/geometry/Config.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/geometry/Config.h
+++ b/src/modules/timepix3/geometry/Config.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/geometry/Timepix3Geometry.cpp
+++ b/src/modules/timepix3/geometry/Timepix3Geometry.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/geometry/Timepix3Geometry.h
+++ b/src/modules/timepix3/geometry/Timepix3Geometry.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/handlers/PixelEventHandler.cpp
+++ b/src/modules/timepix3/handlers/PixelEventHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/handlers/PixelEventHandler.h
+++ b/src/modules/timepix3/handlers/PixelEventHandler.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2024 - 2025 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/handlers/TimingEventHandler.cpp
+++ b/src/modules/timepix3/handlers/TimingEventHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/handlers/TimingEventHandler.h
+++ b/src/modules/timepix3/handlers/TimingEventHandler.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/readout/DataParser.cpp
+++ b/src/modules/timepix3/readout/DataParser.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/readout/DataParser.h
+++ b/src/modules/timepix3/readout/DataParser.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/test/Timepix3BaseTest.cpp
+++ b/src/modules/timepix3/test/Timepix3BaseTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, see LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, see LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/test/Timepix3GeometryTest.cpp
+++ b/src/modules/timepix3/test/Timepix3GeometryTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/test/Timepix3InstrumentTest.cpp
+++ b/src/modules/timepix3/test/Timepix3InstrumentTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/test/Timepix3ParserTest.cpp
+++ b/src/modules/timepix3/test/Timepix3ParserTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/test/Timepix3PixelEventHandlerTest.cpp
+++ b/src/modules/timepix3/test/Timepix3PixelEventHandlerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/timepix3/test/Timepix3TimingEventHandlerTest.cpp
+++ b/src/modules/timepix3/test/Timepix3TimingEventHandlerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2023 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file

--- a/src/modules/trex/TREXInstrument.h
+++ b/src/modules/trex/TREXInstrument.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2022 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file


### PR DESCRIPTION
### Issue reference / description
https://jira.ess.eu/browse/ECDC-4535

This is a follow-up PR to https://github.com/ess-dmsc/event-formation-unit/pull/837 fixing hyphens missing in copyright headers. 

## Checklist for submitter

- [x] Check for conflict with integration test
- [x] Unit tests pass

---

### Nominate for Group Code Review

- [x] Nominate for code review
