### PR TITLE
ECDC-4545: Bug in Estia geometry

### DIFF
--- a/src/common/readout/ess/Parser.h
+++ b/src/common/readout/ess/Parser.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cinttypes>
 #include <common/time/ESSTime.h>
 #include <cstddef>
 #include <cstdint>

--- a/src/common/readout/ess/Parser.h
+++ b/src/common/readout/ess/Parser.h
@@ -56,6 +56,7 @@ public:
     CSPEC = 0x40,
     NMX = 0x44,
     FREIA = 0x48,
+    ESTIA = 0x4C,
     TREX = 0x50,
     DREAM = 0x60,
     MAGIC = 0x64,

--- a/src/common/readout/ess/Parser.h
+++ b/src/common/readout/ess/Parser.h
@@ -9,11 +9,9 @@
 
 #pragma once
 
-#include <cinttypes>
 #include <common/time/ESSTime.h>
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 
 namespace ESSReadout {
 

--- a/src/efu/MainProg.cpp
+++ b/src/efu/MainProg.cpp
@@ -8,7 +8,6 @@
 #include <common/StatPublisher.h>
 #include <common/Version.h>
 #include <common/debug/Log.h>
-#include <cstdio>
 #include <efu/ExitHandler.h>
 #include <efu/Launcher.h>
 #include <efu/MainProg.h>

--- a/src/modules/freia/FreiaBase.cpp
+++ b/src/modules/freia/FreiaBase.cpp
@@ -185,6 +185,12 @@ void FreiaBase::processing_thread() {
   RuntimeStat RtStat({ITCounters.RxPackets, Counters.Events,
                       Counters.KafkaStats.produce_bytes_ok});
 
+  uint8_t DataType{ESSReadout::Parser::FREIA};
+
+  if (EFUSettings.DetectorName == "Estia") {
+    DataType = ESSReadout::Parser::ESTIA;
+  }
+
   while (runThreads) {
     if (InputFifo.pop(DataIndex)) { // There is data in the FIFO - do processing
       auto DataLen = RxRingbuffer.getDataLength(DataIndex);
@@ -197,8 +203,7 @@ void FreiaBase::processing_thread() {
       auto DataPtr = RxRingbuffer.getDataBuffer(DataIndex);
 
       int64_t SeqErrOld = Counters.ReadoutStats.ErrorSeqNum;
-      auto Res = Freia.ESSReadoutParser.validate(DataPtr, DataLen,
-                                                 ESSReadout::Parser::FREIA);
+      auto Res = Freia.ESSReadoutParser.validate(DataPtr, DataLen, DataType);
       Counters.ReadoutStats = Freia.ESSReadoutParser.Stats;
 
       if (SeqErrOld != Counters.ReadoutStats.ErrorSeqNum) {

--- a/src/modules/freia/FreiaBase.cpp
+++ b/src/modules/freia/FreiaBase.cpp
@@ -187,7 +187,7 @@ void FreiaBase::processing_thread() {
 
   uint8_t DataType{ESSReadout::Parser::FREIA};
 
-  if (EFUSettings.DetectorName == "Estia") {
+  if (EFUSettings.DetectorName == "estia") {
     DataType = ESSReadout::Parser::ESTIA;
   }
 

--- a/src/modules/freia/FreiaInstrument.cpp
+++ b/src/modules/freia/FreiaInstrument.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 - 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2021 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file
@@ -10,8 +10,11 @@
 
 #include <common/debug/Log.h>
 #include <common/debug/Trace.h>
+#include <common/kafka/EV44Serializer.h>
 #include <common/readout/vmm3/Readout.h>
 #include <common/time/TimeString.h>
+#include <freia/Counters.h>
+#include <freia/FreiaBase.h>
 #include <freia/FreiaInstrument.h>
 
 // #undef TRC_LEVEL

--- a/src/modules/freia/FreiaInstrument.h
+++ b/src/modules/freia/FreiaInstrument.h
@@ -36,19 +36,11 @@ public:
   /// files. This step will throw an exception upon errors.
   void loadConfigAndCalib();
 
-  /// \brief after loading the config file, Config.HybridIdStr contains
-  /// a vector of HybridIds. These are then loaded into the Hybrids so that
-  /// we can later do consistency checks when applying the calibration data
-  void setHybridIds(const std::vector<std::string> &Ids);
-
   /// \brief process parsed vmm data into clusters
   void processReadouts(void);
 
   /// \brief process clusters into events
   void generateEvents(std::vector<Event> &Events);
-
-  /// \brief dump readout data to HDF5
-  void dumpReadoutToFile(const ESSReadout::VMM3Parser::VMM3Data &Data);
 
   /// \brief initialise the serializer. This is used both in FreiaInstrument
   // and FreiaBase. Called from FreiaBase

--- a/src/modules/freia/FreiaInstrument.h
+++ b/src/modules/freia/FreiaInstrument.h
@@ -10,16 +10,22 @@
 
 #pragma once
 
-#include <common/kafka/EV44Serializer.h>
 #include <common/readout/ess/Parser.h>
 #include <common/readout/vmm3/Hybrid.h>
 #include <common/readout/vmm3/Readout.h>
 #include <common/readout/vmm3/VMM3Parser.h>
 #include <common/reduction/EventBuilder2D.h>
-#include <freia/Counters.h>
-#include <freia/FreiaBase.h>
 #include <freia/geometry/Config.h>
 #include <freia/geometry/Geometry.h>
+
+#include <memory>
+#include <vector>
+
+// Forward declarations
+class EV44Serializer;
+class Event;
+struct BaseSettings;
+struct Counters;
 
 namespace Freia {
 

--- a/src/modules/freia/geometry/EstiaChannelMapping.h
+++ b/src/modules/freia/geometry/EstiaChannelMapping.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include<cinttypes>
 #include <common/debug/Trace.h>
 #include <freia/geometry/GeometryBase.h>
 

--- a/src/modules/freia/geometry/EstiaChannelMapping.h
+++ b/src/modules/freia/geometry/EstiaChannelMapping.h
@@ -12,8 +12,6 @@
 
 #include <common/debug/Trace.h>
 #include <freia/geometry/GeometryBase.h>
-#include <string>
-#include <vector>
 
 // #undef TRC_LEVEL
 // #define TRC_LEVEL TRC_L_DEB
@@ -50,6 +48,7 @@ public:
   /// yoffset = (cass/48) * 64
   /// y = strip - 1       ( == 63 - channel )
   uint16_t yCoord(uint16_t YOffset, uint8_t VMM, uint8_t Channel) {
+    XTRACE(DATA, DEB, "YOffset %u, VMM %u, Channel %u", YOffset, VMM, Channel);
     if (Channel >= NumStrips) {
       XTRACE(DATA, WAR, "Invalid Channel %d (Max %d)", Channel, NumStrips - 1);
       return InvalidCoord;

--- a/src/modules/freia/geometry/EstiaChannelMapping.h
+++ b/src/modules/freia/geometry/EstiaChannelMapping.h
@@ -10,10 +10,10 @@
 
 #pragma once
 
-#include<cinttypes>
 #include <common/debug/Trace.h>
 #include <freia/geometry/GeometryBase.h>
 
+#include <cinttypes>
 // #undef TRC_LEVEL
 // #define TRC_LEVEL TRC_L_DEB
 

--- a/src/modules/freia/geometry/FreiaChannelMapping.h
+++ b/src/modules/freia/geometry/FreiaChannelMapping.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include<cinttypes>
 #include <common/debug/Trace.h>
 #include <freia/geometry/GeometryBase.h>
 

--- a/src/modules/freia/geometry/FreiaChannelMapping.h
+++ b/src/modules/freia/geometry/FreiaChannelMapping.h
@@ -10,9 +10,10 @@
 
 #pragma once
 
-#include<cinttypes>
 #include <common/debug/Trace.h>
 #include <freia/geometry/GeometryBase.h>
+
+#include <cinttypes>
 
 // #undef TRC_LEVEL
 // #define TRC_LEVEL TRC_L_DEB

--- a/src/modules/freia/geometry/FreiaChannelMapping.h
+++ b/src/modules/freia/geometry/FreiaChannelMapping.h
@@ -12,8 +12,6 @@
 
 #include <common/debug/Trace.h>
 #include <freia/geometry/GeometryBase.h>
-#include <string>
-#include <vector>
 
 // #undef TRC_LEVEL
 // #define TRC_LEVEL TRC_L_DEB
@@ -45,6 +43,7 @@ public:
   /// wire = 32 - (channel - 15)
   /// y = cass * 32 + 32 - wire (= cass * 32 + 47 - channel)
   uint16_t yCoord(uint16_t YOffset, uint8_t VMM, uint8_t Channel) {
+    XTRACE(DATA, DEB, "YOffset %u, VMM %u, Channel %u", YOffset, VMM, Channel);
 
     if ((Channel < MinWireChannel) or (Channel > MaxWireChannel)) {
       XTRACE(DATA, WAR, "Invalid Channel %d (%d <= ch <= %d)", Channel,

--- a/src/modules/freia/geometry/Geometry.h
+++ b/src/modules/freia/geometry/Geometry.h
@@ -61,7 +61,7 @@ public:
   bool isYCoord(uint8_t VMM) { return GeometryInst->isYCoord(VMM); }
 
   // wrapper for pixel2D
-  uint32_t pixel2D(uint16_t x, uint16_t y) {
+  uint32_t pixel2D(uint16_t x, uint16_t y) const {
     return GeometryInst->essgeom->pixel2D(x, y);
   }
 

--- a/src/modules/freia/geometry/Geometry.h
+++ b/src/modules/freia/geometry/Geometry.h
@@ -61,7 +61,7 @@ public:
   bool isYCoord(uint8_t VMM) { return GeometryInst->isYCoord(VMM); }
 
   // wrapper for pixel2D
-  uint16_t pixel2D(uint16_t x, uint16_t y) {
+  uint32_t pixel2D(uint16_t x, uint16_t y) {
     return GeometryInst->essgeom->pixel2D(x, y);
   }
 

--- a/src/modules/freia/test/FreiaInstrumentTest.cpp
+++ b/src/modules/freia/test/FreiaInstrumentTest.cpp
@@ -1,7 +1,9 @@
-// Copyright (C) 2021 - 2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2021 - 2025 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file
+///
+/// \brief Unit tests for FreiaInstrument
 //===----------------------------------------------------------------------===//
 
 #include <common/kafka/EV44Serializer.h>
@@ -9,6 +11,9 @@
 #include <common/testutils/HeaderFactory.h>
 #include <common/testutils/SaveBuffer.h>
 #include <common/testutils/TestBase.h>
+
+#include <freia/Counters.h>
+#include <freia/FreiaBase.h>
 #include <freia/FreiaInstrument.h>
 
 using namespace Freia;

--- a/src/modules/freia/test/GeometryTest.cpp
+++ b/src/modules/freia/test/GeometryTest.cpp
@@ -73,12 +73,13 @@ TEST_F(GeometryTest, SelectEstia) {
 }
 
 // Checking that correct 2D geometry is loaded
-//GeometryInst->essgeom = new ESSGeometry(1536, 128, 1, 1);
 TEST_F(GeometryTest, EstiaPixels) {
+  // Test using the ESTIA ICD dimensions
+  Geom.setGeometry("Estia");
+
   const uint16_t nx = 1536;
   const uint16_t ny = 128;
 
-  Geom.setGeometry("Estia");
   ASSERT_EQ(1, Geom.pixel2D(     0,      0));
   ASSERT_TRUE( Geom.pixel2D(nx - 1,      0) > 0);
   ASSERT_EQ(0, Geom.pixel2D(    nx,      0));
@@ -86,14 +87,15 @@ TEST_F(GeometryTest, EstiaPixels) {
   ASSERT_EQ(0, Geom.pixel2D(     0,     ny));
 
   // Check that https://jira.ess.eu/browse/ECDC-4545 is fixed by testing that
-  // all four corners are mapped to the expected pixel id
+  // all four corners of the pixel geometry are mapped to the expected pixel id
   std::vector<std::tuple<uint16_t, uint16_t, uint32_t>> testData = {
+    // x       y        pixel ID
     {     0,      0,               1},
     {nx - 1,      0,              nx},
     {     0, ny - 1, nx*(ny - 1) + 1},
     {nx - 1, ny - 1,           nx*ny},
   };
-  for (const auto& [x, y, id]: testData) {
+  for (const auto &[x, y, id]: testData) {
     ASSERT_EQ(id, Geom.pixel2D(x, y));
   }
 }

--- a/src/modules/freia/test/GeometryTest.cpp
+++ b/src/modules/freia/test/GeometryTest.cpp
@@ -75,12 +75,27 @@ TEST_F(GeometryTest, SelectEstia) {
 // Checking that correct 2D geometry is loaded
 //GeometryInst->essgeom = new ESSGeometry(1536, 128, 1, 1);
 TEST_F(GeometryTest, EstiaPixels) {
+  const uint16_t nx = 1536;
+  const uint16_t ny = 128;
+
   Geom.setGeometry("Estia");
-  ASSERT_EQ(1, Geom.pixel2D(   0,   0));
-  ASSERT_TRUE( Geom.pixel2D(1535,   0) > 0);
-  ASSERT_EQ(0, Geom.pixel2D(1536,   0));
-  ASSERT_TRUE( Geom.pixel2D(   0, 127) > 0);
-  ASSERT_EQ(0, Geom.pixel2D(   0, 128));
+  ASSERT_EQ(1, Geom.pixel2D(     0,      0));
+  ASSERT_TRUE( Geom.pixel2D(nx - 1,      0) > 0);
+  ASSERT_EQ(0, Geom.pixel2D(    nx,      0));
+  ASSERT_TRUE( Geom.pixel2D(     0, ny - 1) > 0);
+  ASSERT_EQ(0, Geom.pixel2D(     0,     ny));
+
+  // Check that https://jira.ess.eu/browse/ECDC-4545 is fixed by testing that
+  // all four corners are mapped to the expected pixel id
+  std::vector<std::tuple<uint16_t, uint16_t, uint32_t>> testData = {
+    {     0,      0,               1},
+    {nx - 1,      0,              nx},
+    {     0, ny - 1, nx*(ny - 1) + 1},
+    {nx - 1, ny - 1,           nx*ny},
+  };
+  for (const auto& [x, y, id]: testData) {
+    ASSERT_EQ(id, Geom.pixel2D(x, y));
+  }
 }
 
 TEST_F(GeometryTest, SelectInvalid) {

--- a/src/modules/freia/test/GeometryTest.cpp
+++ b/src/modules/freia/test/GeometryTest.cpp
@@ -36,16 +36,31 @@ TEST_F(GeometryTest, SelectFreia) {
   ASSERT_TRUE(Geom.isYCoord(VMM0));
 }
 
-// CHecking that correct 2D geometry is loaded
+// Checking that correct 2D geometry is loaded
 TEST_F(GeometryTest, FreiaPixels) {
+  // Test using the Freia ICD dimensions
   Geom.setGeometry("AMOR");
   Geom.setGeometry("Freia");
+  const uint16_t nx = 64;
+  const uint16_t ny = 1024;
 
-  ASSERT_EQ(1, Geom.pixel2D( 0,    0));
-  ASSERT_TRUE( Geom.pixel2D(63,    0) > 0);
-  ASSERT_EQ(0, Geom.pixel2D(64,    0));
-  ASSERT_TRUE( Geom.pixel2D( 0, 1023) > 0);
-  ASSERT_EQ(0, Geom.pixel2D( 0, 1024));
+  ASSERT_EQ(1, Geom.pixel2D(     0,      0));
+  ASSERT_TRUE( Geom.pixel2D(nx - 1,      0) > 0);
+  ASSERT_EQ(0, Geom.pixel2D(    nx,      0));
+  ASSERT_TRUE( Geom.pixel2D(     0, ny - 1) > 0);
+  ASSERT_EQ(0, Geom.pixel2D(     0,     ny));
+
+  // Test that all four corners of the pixel geometry are mapped to the expected pixel id
+  std::vector<std::tuple<uint16_t, uint16_t, uint16_t, uint32_t>> testData = {
+  // #     x       y       Pixel ID
+    {1,      0,      0,               1},
+    {2, nx - 1,      0,              nx},
+    {3,      0, ny - 1, nx*(ny - 1) + 1},
+    {4, nx - 1, ny - 1,           nx*ny},
+  };
+  for (const auto &[corner, x, y, id]: testData) {
+    ASSERT_EQ(id, Geom.pixel2D(x, y)) << "Pixel ID test failed for corner #" << std::to_string(corner);
+  }
 }
 
 // x- and y- vmms are swapped compared with Freia
@@ -57,14 +72,29 @@ TEST_F(GeometryTest, SelectAMOR) {
 
 // Checking that correct 2D geometry is loaded
 TEST_F(GeometryTest, AMORPixels) {
+  // Test using the AMOR ICD dimensions
   Geom.setGeometry("AMOR");
-  ASSERT_EQ(1, Geom.pixel2D( 0,   0));
-  ASSERT_TRUE( Geom.pixel2D(63,   0) > 0);
-  ASSERT_EQ(0, Geom.pixel2D(64,   0));
-  ASSERT_TRUE( Geom.pixel2D( 0, 447) > 0);
-  ASSERT_EQ(0, Geom.pixel2D( 0, 448));
-}
+  const uint16_t nx = 64;
+  const uint16_t ny = 448;
 
+  ASSERT_EQ(1, Geom.pixel2D(     0,      0));
+  ASSERT_TRUE( Geom.pixel2D(nx - 1,      0) > 0);
+  ASSERT_EQ(0, Geom.pixel2D(    nx,      0));
+  ASSERT_TRUE( Geom.pixel2D(     0, ny - 1) > 0);
+  ASSERT_EQ(0, Geom.pixel2D(     0,     ny));
+
+  // Test that all four corners of the pixel geometry are mapped to the expected pixel id
+  std::vector<std::tuple<uint16_t, uint16_t, uint16_t, uint32_t>> testData = {
+  // #     x       y       Pixel ID
+    {1,      0,      0,               1},
+    {2, nx - 1,      0,              nx},
+    {3,      0, ny - 1, nx*(ny - 1) + 1},
+    {4, nx - 1, ny - 1,           nx*ny},
+  };
+  for (const auto &[corner, x, y, id]: testData) {
+    ASSERT_EQ(id, Geom.pixel2D(x, y)) << "Pixel ID test failed for corner #" << std::to_string(corner);
+  }
+}
 
 TEST_F(GeometryTest, SelectEstia) {
   ASSERT_TRUE(Geom.setGeometry("Estia"));
@@ -76,7 +106,6 @@ TEST_F(GeometryTest, SelectEstia) {
 TEST_F(GeometryTest, EstiaPixels) {
   // Test using the ESTIA ICD dimensions
   Geom.setGeometry("Estia");
-
   const uint16_t nx = 1536;
   const uint16_t ny = 128;
 
@@ -88,15 +117,15 @@ TEST_F(GeometryTest, EstiaPixels) {
 
   // Check that https://jira.ess.eu/browse/ECDC-4545 is fixed by testing that
   // all four corners of the pixel geometry are mapped to the expected pixel id
-  std::vector<std::tuple<uint16_t, uint16_t, uint32_t>> testData = {
-    // x       y        pixel ID
-    {     0,      0,               1},
-    {nx - 1,      0,              nx},
-    {     0, ny - 1, nx*(ny - 1) + 1},
-    {nx - 1, ny - 1,           nx*ny},
+  std::vector<std::tuple<uint16_t, uint16_t, uint16_t, uint32_t>> testData = {
+  // #     x       y       Pixel ID
+    {1,      0,      0,               1},
+    {2, nx - 1,      0,              nx},
+    {3,      0, ny - 1, nx*(ny - 1) + 1},
+    {4, nx - 1, ny - 1,           nx*ny},
   };
-  for (const auto &[x, y, id]: testData) {
-    ASSERT_EQ(id, Geom.pixel2D(x, y));
+  for (const auto &[corner, x, y, id]: testData) {
+    ASSERT_EQ(id, Geom.pixel2D(x, y)) << "Pixel ID test failed for corner #" << std::to_string(corner);
   }
 }
 


### PR DESCRIPTION
### Issue reference / description
https://jira.ess.eu/browse/ECDC-4545

The respective pixel data sizes for the AMOR and FREIA instruments are defined in `Freia::Geometry` as 

- 64 × 448 = 28672
- 64 × 1024 = 2<sup>16</sup>

Both these sizes fit within the resolution of the type `uint16_t`.

However, for the newly added ESTIA instrument, the required pixel data size is 

<p align="center">
1536 × 128 = 2 × 768 × 128 = 2 (2<sup>8</sup> + 2<sup>9</sup>) 2<sup>7</sup> = 3 × 2<sup>16</sup>
</p>

For higher valued pixels, this will overflow for `uint16_t`. For this particular case, the bug is caused by an overflow caused by the return type of the method

```
uint16_t Freia::Geometry::pixel2D(uint16_t x, uint16_t y)
```

The overflow effect can be seen in the daqlite screenshot below

![bad](https://github.com/user-attachments/assets/a6fd597b-e781-4123-9efd-64b5a4510361)

The white pixels should lie on a straight line, but do not. Also, the y-coordinate of the pixel should satisfy y ≥ 64.

Modifying the return type of the method `Freia::Geometry::pixel2D` to `uint32_t` fixes the problem

```
uint32_t Freia::Geometry::pixel2D(uint16_t x, uint16_t y)
```

As seen below, the pixels are now correctly located on a straight line and the y-coordinate of the pixel satisfy y ≥ 64.

![good](https://github.com/user-attachments/assets/187ea599-4600-4ffc-b607-fb7f63c5f6e8)

### Note
The actual bug fix is in this [commit](https://github.com/ess-dmsc/event-formation-unit/pull/846/commits/5c6728d946daf8c305a3ce971eb118aaf2e24b77) 

## Checklist for submitter

- [x] Check for conflict with integration test
- [x] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
