### PR TITLE
ECDC-4570 introduce central kafka config thorugh kafka config

### DIFF
--- a/src/common/kafka/KafkaConfig.h
+++ b/src/common/kafka/KafkaConfig.h
@@ -24,9 +24,10 @@ public:
   std::vector<std::pair<std::string, std::string>> CfgParms;
 
   static inline std::vector<std::pair<std::string, std::string>> DefaultConfig{
-      {"message.max.bytes", "10000000"},
-      {"message.copy.max.bytes", "10000000"},
+      {"message.max.bytes", "10000000"},      // max size of a msg (10MB)
+      {"message.copy.max.bytes", "10000000"}, // max bytes of a msg to copy over into kafka buffer (10MB)
       {"queue.buffering.max.ms", "100"},
-      {"statistics.interval.ms", "1000"},
+      {"statistics.interval.ms", "1000"},    // every sec read out kafka statistic
+      {"message.timeout.ms", "600000"},      // 10 minutes to keep msg memory
       {"api.version.request", "true"}};
 };

--- a/src/common/kafka/Producer.h
+++ b/src/common/kafka/Producer.h
@@ -103,6 +103,10 @@ public:
     int64_t TransmissionErrors{0};
     /// \brief Count of delivery reports with errors
     int64_t MsgError{0};
+    /// \brief Total count of statistics events
+    int64_t StatsEventCounter{0};
+    /// \brief Total count of error events
+    int64_t ErrorEventCounter{0};
 
     // librdkafka message statistics
     /// \brief Count of successful message deliveries

--- a/src/common/kafka/kafka.json
+++ b/src/common/kafka/kafka.json
@@ -4,6 +4,8 @@
     {"fetch.message.max.bytes" : "10000000"},
     {"message.copy.max.bytes" : "10000000"},
     {"queue.buffering.max.ms" : "100"},
+    {"statistics.interval.ms" : "1000"},
+    {"message.timeout.ms" : "600000"},
     {"api.version.request" : "true"}
   ]
 }


### PR DESCRIPTION
files. Add statistics interval to kafka config.

### Issue reference / description

The branch you merge from should already reference an event-formation-unit github ticket number. You can add a descriptive title, but if an issue is referenced, you don't have to.

## Checklist for submitter

- [ ] Check for conflict with integration test
- [ ] Unit tests pass

---

### Nominate for Group Code Review

- [ ] Nominate for code review
